### PR TITLE
[#109060102] Add new container curl-ssl

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ before_install:
   - bundle install
   - bundle exec rake build:bosh_init
   - bundle exec rake build:spruce
+  - bundle exec rake build:curl_ssl
 
 script:
   - cd ${TRAVIS_BUILD_DIR} && bundle exec rake

--- a/README.md
+++ b/README.md
@@ -8,3 +8,4 @@ List:
 
 * [bosh-init](https://github.com/alphagov/paas-docker-cloudfoundry-tools/tree/master/bosh-init)
 * [spruce](https://github.com/alphagov/paas-docker-cloudfoundry-tools/tree/master/spruce)
+* [curl-ssl](https://github.com/alphagov/paas-docker-cloudfoundry-tools/tree/master/curl-ssl)

--- a/Rakefile
+++ b/Rakefile
@@ -10,11 +10,15 @@ namespace :build do
     system "cd spruce && docker build -t spruce ."
   end
 
+  desc "Build curl-ssl image"
+  task :curl_ssl do
+    system "cd curl-ssl && docker build -t curl-ssl ."
+  end
 end
 
 require 'rspec/core/rake_task'
 
-task :spec => ["spec:bosh-init", "spec:spruce"]
+task :spec => ["spec:bosh-init", "spec:spruce", "spec:curl_ssl"]
 task :default => :spec
 
 namespace :spec do
@@ -29,4 +33,8 @@ namespace :spec do
     t.pattern = "spec/spruce/**/*_spec.rb"
   end
 
+  desc "Run all specs for curl-ssl"
+  RSpec::Core::RakeTask.new("curl_ssl") do |t|
+    t.pattern = "spec/curl-ssl/**/*_spec.rb"
+  end
 end

--- a/curl-ssl/Dockerfile
+++ b/curl-ssl/Dockerfile
@@ -1,0 +1,7 @@
+FROM alpine:3.3
+
+ENV PACKAGES "curl openssl ca-certificates"
+
+RUN apk add --update $PACKAGES && rm -rf /var/cache/apk/*
+
+

--- a/curl-ssl/README.md
+++ b/curl-ssl/README.md
@@ -1,0 +1,19 @@
+Includes curl with SSL and openssl support, including the `openssl` command.
+
+It also includes the ca-certificates.
+
+Based on [alpine](https://hub.docker.com/_/alpine/) image.
+
+## Build locally
+
+```
+$ cd bosh-init
+$ docker build -t curl-ssl .
+```
+
+## Run
+
+```
+docker run -i -t curl-ssl curl https://www.google.com
+docker run -i -t curl-ssl openssl
+```

--- a/spec/curl-ssl/curl-ssl_spec.rb
+++ b/spec/curl-ssl/curl-ssl_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+require 'docker'
+require 'serverspec'
+
+describe "bosh-init image" do
+  before(:all) {
+    @image = Docker::Image.all().detect{|i| i.info['RepoTags'].include? 'curl-ssl:latest' }
+    set :docker_image, @image.id
+  }
+
+  it "should be available" do
+    expect(@image).to_not be_nil
+  end
+
+  it "installs the right version of Alpine" do
+    expect(os_version).to include("Alpine Linux 3.3")
+  end
+
+  def os_version
+    command("cat /etc/issue | head -1").stdout
+  end
+
+  it "installs required packages" do
+    CURL_SSL_PACKAGES.split(' ').each do |package|
+      expect(command("apk -vv info | grep #{package}").exit_status).to eq(0)
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,3 +14,7 @@ BOSH_INIT_VERSION = "0.0.80-a62aad7-2015-10-28T01:52:30Z"
 
 SPRUCE_BIN = "/go/bin/spruce"
 SPRUCE_VERSION = "0.13.0"
+
+# curl-ssl
+
+CURL_SSL_PACKAGES = "curl openssl ca-certificates"


### PR DESCRIPTION
[#109060102 Add new container curl-ssl](https://www.pivotaltracker.com/story/show/109060102)

# What

Implement a new container curl-ssl which includes the curl command with SSL support and openssl binary.

The container is based on Alpine:3.3

The spec check won't use the serverspec package resource because it does
not support alpine. Instead, we use the `apk` command directly.

# Dependencies

This PR depends on #8 being merged first, to pin the spruce version (merged already)

# How to test it

Using the rake file (I recommend use of [RVM](http://getrvm.io)):

```
bundle install
bundle exec rake build:curl_ssl spec:curl_ssl
```

You can also test the commands:

```
docker run -i -t curl-ssl curl https://www.google.com
docker run -i -t curl-ssl openssl
```

# Who?

Anyone but @keymon