### PR TITLE
[#109060102] Implement logic to pin the spruce version

### DIFF
--- a/spec/spruce/spruce_spec.rb
+++ b/spec/spruce/spruce_spec.rb
@@ -29,7 +29,7 @@ describe "spruce image" do
   end
 
   it "has the spruce version #{SPRUCE_VERSION}" do
-    expect(spruce_version).to eq("spruce - Version #{SPRUCE_VERSION} (master)")
+    expect(spruce_version).to eq("spruce - Version #{SPRUCE_VERSION}")
   end
 
   def spruce_version

--- a/spruce/Dockerfile
+++ b/spruce/Dockerfile
@@ -1,6 +1,11 @@
 FROM golang:1.5.1-alpine
 
-RUN apk update
-RUN apk add git \
+ENV SPRUCE_VERSION 0.12.0
+
+RUN apk add --update git \
   && go get github.com/geofffranks/spruce \
-  && apk del git
+  && cd ${GOPATH}/src/github.com/geofffranks/spruce \
+  && git checkout v${SPRUCE_VERSION} \
+  && go install \
+  && apk del git \
+  && rm -rf /var/cache/apk/*


### PR DESCRIPTION
[#109060102 Implement logic to pin the spruce version](https://www.pivotaltracker.com/story/show/109060102)

What
----

We need to pin the version of the spruce command, to avoid uncontrollerd
upgrades of the spruce binary with any upstream changes.

For that we use git tags to implement version pinning for the spruce command.

We cannot use [release binaries](https://github.com/alphagov/paas-docker-cloudfoundry-tools/tree/spruce_from_release)
because they are dynamically compiled and they fail on alpine, so we get
the spruce code, checkout the version tag
and rebuild the binary.

How to test?
------------

(Note: recommended use a ruby manager like RVM)

```
bundle install
bundle exec rake build:spruce spec:spruce
```

Who?
----

Anyone but @keymon