### PR TITLE
Improve error message when tests can't find image

### DIFF
--- a/spec/bosh-init/bosh-init_spec.rb
+++ b/spec/bosh-init/bosh-init_spec.rb
@@ -4,13 +4,8 @@ require 'serverspec'
 
 describe "bosh-init image" do
   before(:all) {
-    @image = Docker::Image.all().detect{|i| i.info['RepoTags'].include? 'bosh-init:latest' }
-    set :docker_image, @image.id
+    set :docker_image, find_image_id('bosh-init:latest')
   }
-
-  it "should be available" do
-    expect(@image).to_not be_nil
-  end
 
   it "installs the right version of Ubuntu" do
     expect(os_version).to include("Ubuntu 14")

--- a/spec/curl-ssl/curl-ssl_spec.rb
+++ b/spec/curl-ssl/curl-ssl_spec.rb
@@ -4,13 +4,8 @@ require 'serverspec'
 
 describe "bosh-init image" do
   before(:all) {
-    @image = Docker::Image.all().detect{|i| i.info['RepoTags'].include? 'curl-ssl:latest' }
-    set :docker_image, @image.id
+    set :docker_image, find_image_id('curl-ssl:latest')
   }
-
-  it "should be available" do
-    expect(@image).to_not be_nil
-  end
 
   it "installs the right version of Alpine" do
     expect(os_version).to include("Alpine Linux 3.3")

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,3 +18,10 @@ SPRUCE_VERSION = "0.13.0"
 # curl-ssl
 
 CURL_SSL_PACKAGES = "curl openssl ca-certificates"
+
+def find_image_id(name)
+  image = Docker::Image.all().detect{ |i| i.info['RepoTags'].include? name }
+  raise "Docker image '#{name}' not found. You may need to run 'rake build:<name>' first" unless image
+
+  image.id
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,7 +20,7 @@ SPRUCE_VERSION = "0.13.0"
 CURL_SSL_PACKAGES = "curl openssl ca-certificates"
 
 def find_image_id(name)
-  image = Docker::Image.all().detect{ |i| i.info['RepoTags'].include? name }
+  image = Docker::Image.all().detect{|i| i.info['RepoTags'][0].end_with? name }
   raise "Docker image '#{name}' not found. You may need to run 'rake build:<name>' first" unless image
 
   image.id

--- a/spec/spruce/spruce_spec.rb
+++ b/spec/spruce/spruce_spec.rb
@@ -4,13 +4,8 @@ require 'serverspec'
 
 describe "spruce image" do
   before(:all) {
-    @image = Docker::Image.all().detect{|i| i.info['RepoTags'].include? 'spruce:latest' }
-    set :docker_image, @image.id
+    set :docker_image, find_image_id('spruce:latest')
   }
-
-  it "should be available" do
-    expect(@image).to_not be_nil
-  end
 
   it "installs the right version of Alpine Linux" do
     expect(os_version).to include("Alpine Linux 3.2")


### PR DESCRIPTION
It momentarily confused me why the tests wouldn't work locally. I've removed
the `should be available` test because this doesn't report the correct thing
when `@image` is `nil`. Because of this we no longer need `@image`, we just
want the ID.

Before:

    1) bosh-init image should be available
       Failure/Error: set :docker_image, @image.id
       NoMethodError:
         undefined method `id' for nil:NilClass

       # ./spec/bosh-init/bosh-init_spec.rb:8:in `block (2 levels) in <top (required)>'

After:

    1) bosh-init image installs the right version of Ubuntu
       Failure/Error: raise "Docker image '#{name}' not found. You may need to run 'rake build:<name>' first" unless image
       RuntimeError:
         Docker image 'bosh-init:latest' not found. You may need to run 'rake build:<name>' first

       # ./spec/spec_helper.rb:20:in `find_image_id'
       # ./spec/bosh-init/bosh-init_spec.rb:7:in `block (2 levels) in <top (required)>'