### PR TITLE
Revert "Find images by suffix rather than exact match"

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,7 +20,7 @@ SPRUCE_VERSION = "0.13.0"
 CURL_SSL_PACKAGES = "curl openssl ca-certificates"
 
 def find_image_id(name)
-  image = Docker::Image.all().detect{|i| i.info['RepoTags'][0].end_with? name }
+  image = Docker::Image.all().detect{ |i| i.info['RepoTags'].include? name }
   raise "Docker image '#{name}' not found. You may need to run 'rake build:<name>' first" unless image
 
   image.id


### PR DESCRIPTION
This reverts commit cdd1579b9af644b669285bd2e987207b01abb730.

This was intended to work with a remotely pulled image as well as the more
common use case of a locally built image. However if a remote image has been
pulled then the local image will never be used:

    ➜  paas-docker-cloudfoundry-tools git:(master) docker tag -f ubuntu:14.04 spruce
    ➜  paas-docker-cloudfoundry-tools git:(master) docker images | grep spruce
    spruce                   latest              89d5d8e8bafb        4 weeks ago         187.9 MB
    governmentpaas/spruce    latest              9ca91d2c99ff        4 weeks ago         275.3 MB
    ➜  paas-docker-cloudfoundry-tools git:(master) b irb
    irb(main):001:0> require 'docker'
    => true
    irb(main):002:0> Docker::Image.all().detect{|i| i.info['RepoTags'][0].end_with? 'spruce:latest' }.id
    => "9ca91d2c99ff8cfe13d3d0911d9f161d0503035a2860e5336223bd9c921495af"