### PR TITLE
[#111137450] Cache bosh-init AWS CPI compilation in image

### DIFF
--- a/bosh-init/Dockerfile
+++ b/bosh-init/Dockerfile
@@ -12,3 +12,10 @@ RUN apt-get install -y wget
 
 RUN wget -q -O /usr/local/bin/bosh-init --no-check-certificate ${BOSH_INIT_URL}
 RUN chmod +x /usr/local/bin/bosh-init
+
+ENV BOSH_AWS_CPI_URL https://bosh.io/d/github.com/cloudfoundry-incubator/bosh-aws-cpi-release?v=36
+ENV BOSH_AWS_CPI_CHECKSUM db2a6c6cdd5ff9f77bf083e10118fa72e1f5e181
+
+COPY bosh_init_cache /tmp/bosh_init_cache/
+RUN /tmp/bosh_init_cache/seed_bosh_init_cache.sh && \
+    rm -rf /tmp/bosh_init_cache

--- a/bosh-init/README.md
+++ b/bosh-init/README.md
@@ -52,3 +52,12 @@ $ docker run -v /home/ubuntu/docker-bosh-init-manifest:/docker-bosh-init-manifes
 bosh-init deploy /docker-bosh-init-manifest/bosh-manifest.yml
 
 ```
+
+## Caching compile of AWS CPI
+
+The container has been preseeded with a compile of the bosh AWS CPI. If your
+manifest is using the same version, this will speed things up considerably.
+
+The version of the CPi that's cached is controller by the `BOSH_AWS_CPI_URL`
+and `BOSH_AWS_CPI_CHECKSUM` variables in the `Dockerfile`, which should contain
+values that match the `url` and `sha1` parameters of the bosh release.

--- a/bosh-init/bosh_init_cache/minimal-state.json
+++ b/bosh-init/bosh_init_cache/minimal-state.json
@@ -1,0 +1,3 @@
+{
+  "installation_id": "44f01911-a47a-4a24-6ca3-a3109b33f058"
+}

--- a/bosh-init/bosh_init_cache/minimal_in.yml
+++ b/bosh-init/bosh_init_cache/minimal_in.yml
@@ -1,0 +1,24 @@
+---
+name: dummy-deployment
+cloud_provider:
+  template:
+    name: aws_cpi
+    release: bosh-aws-cpi
+releases:
+- name: bosh-aws-cpi
+  sha1: BOSH_AWS_CPI_CHECKSUM
+  url: BOSH_AWS_CPI_URL
+networks:
+- name: dummy
+  type: vip
+resource_pools:
+- name: dummy
+  network: dummy
+  stemcell:
+    sha1: 1a29c43d4e8abf7476ed6bb83168df1bdb742022
+    url: https://bosh.io/d/stemcells/bosh-aws-xen-hvm-ubuntu-trusty-go_agent?v=3074
+jobs:
+- name: dummy
+  networks:
+  - name: dummy
+  resource_pool: dummy

--- a/bosh-init/bosh_init_cache/seed_bosh_init_cache.sh
+++ b/bosh-init/bosh_init_cache/seed_bosh_init_cache.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+set -e
+set -u
+
+WORKING_DIR=$(cd $(dirname "${0}") && pwd)
+
+cd "${WORKING_DIR}"
+
+sed "s|BOSH_AWS_CPI_URL|${BOSH_AWS_CPI_URL}|; s|BOSH_AWS_CPI_CHECKSUM|${BOSH_AWS_CPI_CHECKSUM}|" minimal_in.yml > minimal.yml
+
+echo "###############################################"
+echo "# Compiling AWS CPI release...                #"
+echo "# The deploy will error, but that's expected. #"
+echo "###############################################"
+
+set +e
+bosh-init deploy minimal.yml
+set -e
+
+echo "...done"

--- a/spec/bosh-init/bosh-init_spec.rb
+++ b/spec/bosh-init/bosh-init_spec.rb
@@ -34,11 +34,18 @@ describe "bosh-init image" do
   end
 
   it "contains the compiled CPI packages" do
-    cmd = command('cat /root/.bosh_init/installations/*/compiled_packages.json')
-    expect(cmd.exit_status).to eq(0)
-    compiled_packages = JSON.parse(cmd.stdout)
+    installation_path = '/root/.bosh_init/installations/44f01911-a47a-4a24-6ca3-a3109b33f058'
+    packages_file = file("#{installation_path}/compiled_packages.json")
+    expect(packages_file).to exist
+    compiled_packages = JSON.parse(packages_file.content)
+    compiled_packages.each do |package|
+      expect(file("#{installation_path}/blobs/#{package["Value"]["BlobID"]}")).to exist
+    end
+
     cpi_package = compiled_packages.find {|p| p["Key"]["PackageName"] == "bosh_aws_cpi" }
     expect(cpi_package).to be
+
+    expect(file("#{installation_path}/packages/bosh_aws_cpi/bin/aws_cpi")).to be_executable
   end
 
   def bosh_init_version

--- a/spec/bosh-init/bosh-init_spec.rb
+++ b/spec/bosh-init/bosh-init_spec.rb
@@ -33,6 +33,14 @@ describe "bosh-init image" do
     expect(bosh_init_version).to eq("version #{BOSH_INIT_VERSION}")
   end
 
+  it "contains the compiled CPI packages" do
+    cmd = command('cat /root/.bosh_init/installations/*/compiled_packages.json')
+    expect(cmd.exit_status).to eq(0)
+    compiled_packages = JSON.parse(cmd.stdout)
+    cpi_package = compiled_packages.find {|p| p["Key"]["PackageName"] == "bosh_aws_cpi" }
+    expect(cpi_package).to be
+  end
+
   def bosh_init_version
     command("bosh-init --version").stdout.strip
   end


### PR DESCRIPTION
## Problem

Every time bosh-init runs in concourse it has to compile the CPI, which takes 3-5 minutes

## Solution

This adds a step to the build for the bosh-init container to run a dummy deploy which in turn causes the CPI to be compiled and cached in `/root/.bosh_init`.

## Issues/limitations

The cached CPI version has to match the version being used in the manifests used by bosh-init for the cache to be used.

Secondly, the compilation cache is keyed from the `installation_id` which is written to the bosh state.json file. bosh-init generates a random id for new deployments that don't yet have a state file. To work around this, this creates a state.json file containing a predefined installation_id before running bosh-init.  To use the cached version it's then necessary for all runs of bosh-init to use this same `installation_id` (see alphagov/paas-cf#37).