### PR TITLE
[#108441228] Add container for AWS cli tool

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ before_install:
   - bundle exec rake build:spruce
   - bundle exec rake build:curl_ssl
   - bundle exec rake build:mksecrets
+  - bundle exec rake build:awscli
 
 script:
   - cd ${TRAVIS_BUILD_DIR} && bundle exec rake

--- a/Rakefile
+++ b/Rakefile
@@ -19,6 +19,12 @@ namespace :build do
   task :mksecrets do
     system "cd mksecrets && docker build -t mksecrets ."
   end
+
+  desc "Build awscli image"
+  task :awscli do
+    system "cd awscli && docker build -t awscli ."
+  end
+
 end
 
 require 'rspec/core/rake_task'
@@ -46,5 +52,10 @@ namespace :spec do
   desc "Run all specs for mksecrets"
   RSpec::Core::RakeTask.new("mksecrets") do |t|
     t.pattern = "spec/mksecrets/**/*_spec.rb"
+  end
+
+  desc "Run all specs for awscli"
+  RSpec::Core::RakeTask.new("awscli") do |t|
+    t.pattern = "spec/awscli/**/*_spec.rb"
   end
 end

--- a/awscli/Dockerfile
+++ b/awscli/Dockerfile
@@ -1,7 +1,7 @@
 FROM governmentpaas/curl-ssl
 
 ENV AWSCLI_VERSION "1.9.21"
-ENV PACKAGES "python py-pip"
+ENV PACKAGES "groff less python py-pip"
 
 RUN apk add --update $PACKAGES \
     && pip install awscli==$AWSCLI_VERSION \

--- a/awscli/Dockerfile
+++ b/awscli/Dockerfile
@@ -1,0 +1,11 @@
+FROM governmentpaas/curl-ssl
+
+ENV AWSCLI_VERSION "1.9.21"
+ENV PACKAGES "python py-pip"
+
+RUN apk add --update $PACKAGES \
+    && pip install awscli==$AWSCLI_VERSION \
+    && apk --purge -v del py-pip \
+    && rm -rf /var/cache/apk/*
+
+

--- a/awscli/README.md
+++ b/awscli/README.md
@@ -1,0 +1,20 @@
+Includes AWS client tools (`awscli`) to interact with the AWS platform via
+command line.
+
+Also curl with SSL and openssl support is included, to allow scripting HTTP
+calls if necessary (e.g. query metadata)
+
+Based on [alpine](https://hub.docker.com/_/alpine/) image.
+
+## Build locally
+
+```
+$ cd awscli
+$ docker build -t awscli.
+```
+
+## Run
+
+```
+docker run -i -t awscli aws help
+```

--- a/spec/awscli/awscli_spec.rb
+++ b/spec/awscli/awscli_spec.rb
@@ -24,10 +24,20 @@ describe "awscli image" do
   end
 
   it "has the 'aws' version #{AWSCLI_VERSION}" do
+    def awscli_version
+      command("aws --version").stderr.strip
+    end
     expect(awscli_version).to match(/aws-cli\/#{AWSCLI_VERSION} /)
   end
 
-  def awscli_version
-    command("aws --version").stderr.strip
+  it "the 'aws help' command works" do
+    expect(command("aws help").stdout).to match(/SYNOPSIS/)
   end
+
+  it "installs required packages" do
+    AWSCLI_PACKAGES.split(' ').each do |package|
+      expect(command("apk -vv info | grep #{package}").exit_status).to eq(0)
+    end
+  end
+
 end

--- a/spec/awscli/awscli_spec.rb
+++ b/spec/awscli/awscli_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+require 'docker'
+require 'serverspec'
+
+describe "awscli image" do
+  before(:all) {
+    set :docker_image, find_image_id('awscli:latest')
+  }
+
+  it "installs the right version of Alpine Linux" do
+    expect(os_version).to include("Alpine Linux 3.3")
+  end
+
+  def os_version
+    command("cat /etc/issue | head -1").stdout
+  end
+
+  it "checks if 'aws' binary exists and is a file" do
+    expect(file(AWSCLI_BIN)).to be_file
+  end
+
+  it "checks if 'aws' binary is executable" do
+    expect(file(AWSCLI_BIN)).to be_mode 755
+  end
+
+  it "has the 'aws' version #{AWSCLI_VERSION}" do
+    expect(awscli_version).to match(/aws-cli\/#{AWSCLI_VERSION} /)
+  end
+
+  def awscli_version
+    command("aws --version").stderr.strip
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -32,6 +32,8 @@ MKSECRETS_PACKAGES = "pwgen"
 MKPASSWD_BIN = "/usr/bin/mkpasswd"
 
 # awscli
-#
+
+AWSCLI_PACKAGES = "curl openssl ca-certificates less"
+
 AWSCLI_BIN = "/usr/bin/aws"
 AWSCLI_VERSION = "1.9.21"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -30,3 +30,8 @@ end
 
 MKSECRETS_PACKAGES = "pwgen"
 MKPASSWD_BIN = "/usr/bin/mkpasswd"
+
+# awscli
+#
+AWSCLI_BIN = "/usr/bin/aws"
+AWSCLI_VERSION = "1.9.21"


### PR DESCRIPTION
[#108441228 Automatically shutdown dev environments at night / weekends](https://www.pivotaltracker.com/story/show/108441228)

What
----

We want to be able to stop the vagrant AWS vm at nights. We will use AWS
cli tools to send the command to terminate it.

Scope
-----

Add a container including the AWS client tools. We create it based on
the curl container, so that we can use curl for querying the metadata.

How to test this?
-----------------

Run the tests:

```
bundle install # I recommend rvm
rake build:awscli spec:awscli
```

Run the container:

```
docker run awscli aws --version
```

Who?
----
Anyone but @keymon or @actionjack