### PR TITLE
[#111428758] Add a container certstrap CA manager tool

### DIFF
--- a/certstrap/Dockerfile
+++ b/certstrap/Dockerfile
@@ -3,7 +3,7 @@ FROM golang:1.5.3-alpine
 ENV GIT_COMMIT 8b3cd66cfe2433e2e998c46a618eb09f732c2c2c
 ENV CERTSTRAP_VERSION 0.1.0
 
-RUN apk add --update git bash openssl \
+RUN apk add --update git bash openssl curl ca-certificates \
   && go get -d github.com/square/certstrap \
   && cd ${GOPATH}/src/github.com/square/certstrap \
   && git checkout ${GIT_COMMIT} \

--- a/certstrap/Dockerfile
+++ b/certstrap/Dockerfile
@@ -1,0 +1,13 @@
+FROM golang:1.5.3-alpine
+
+ENV GIT_COMMIT 8b3cd66cfe2433e2e998c46a618eb09f732c2c2c
+ENV CERTSTRAP_VERSION 0.1.0
+
+RUN apk add --update git bash openssl \
+  && go get -d github.com/square/certstrap \
+  && cd ${GOPATH}/src/github.com/square/certstrap \
+  && git checkout ${GIT_COMMIT} \
+  && ./build \
+  && cp bin/certstrap /usr/local/bin \
+  && apk del git bash \
+  && rm -rf /var/cache/apk/* ${GOPATH}

--- a/certstrap/README.md
+++ b/certstrap/README.md
@@ -2,9 +2,11 @@ Installs [certstrap](https://github.com/square/certstrap/).
 
 It uses a go alpine linux image as base to be able to compile go and keep a small image size.
 
-## Requirements
+## Requirements and tools installed
 
-certstrap is a simple certificate manager based on openssl
+certstrap is a simple certificate manager based on `openssl`. In order to
+use scripts which interact with HTTP APIs (e.g. S3) `curl` and
+the `ca-certificates` are installed.
 
 ## Build locally
 
@@ -19,11 +21,12 @@ $ docker build -t certstrap .
 
 ```
 $ docker run -v certstrap certstrap -h
+$ docker run -v certstrap curl
 ```
 
 ### From Dockerhub image
 
 ```
 $ docker run -v governmentpaas/certstrap certstrap -h
-
+$ docker run -v governmentpaas/certstrap curl -h
 ```

--- a/certstrap/README.md
+++ b/certstrap/README.md
@@ -1,0 +1,29 @@
+Installs [certstrap](https://github.com/square/certstrap/).
+
+It uses a go alpine linux image as base to be able to compile go and keep a small image size.
+
+## Requirements
+
+certstrap is a simple certificate manager based on openssl
+
+## Build locally
+
+```
+$ cd certstrap
+$ docker build -t certstrap .
+```
+
+## Run
+
+### Locally
+
+```
+$ docker run -v certstrap certstrap -h
+```
+
+### From Dockerhub image
+
+```
+$ docker run -v governmentpaas/certstrap certstrap -h
+
+```

--- a/certstrap/certstrap_spec.rb
+++ b/certstrap/certstrap_spec.rb
@@ -4,7 +4,7 @@ require 'serverspec'
 
 CERTSTRAP_BIN = "/usr/local/bin/certstrap"
 CERTSTRAP_VERSION = "0.1.0"
-CERTSTRAP_PACKAGES = "openssl"
+CERTSTRAP_PACKAGES = "openssl curl"
 
 describe "certstrap image" do
   before(:all) {

--- a/certstrap/certstrap_spec.rb
+++ b/certstrap/certstrap_spec.rb
@@ -1,0 +1,43 @@
+require 'spec_helper'
+require 'docker'
+require 'serverspec'
+
+CERTSTRAP_BIN = "/usr/local/bin/certstrap"
+CERTSTRAP_VERSION = "0.1.0"
+CERTSTRAP_PACKAGES = "openssl"
+
+describe "certstrap image" do
+  before(:all) {
+    set :docker_image, find_image_id('certstrap:latest')
+  }
+
+  it "installs the right version of Alpine Linux" do
+    expect(os_version).to include("Alpine Linux 3.3")
+  end
+
+  def os_version
+    command("cat /etc/issue | head -1").stdout
+  end
+
+  it "checks if certstrap binary exists and is a file" do
+    expect(file(CERTSTRAP_BIN)).to be_file
+  end
+
+  it "checks if certstrap binary is executable" do
+    expect(file(CERTSTRAP_BIN)).to be_mode 755
+  end
+
+  it "has the certstrap version #{CERTSTRAP_VERSION}" do
+    expect(certstrap_version).to match(/certstrap version #{CERTSTRAP_VERSION}/)
+  end
+
+  def certstrap_version
+    command("certstrap --version").stdout.strip
+  end
+
+  it "installs required packages" do
+    CERTSTRAP_PACKAGES.split(' ').each do |package|
+      expect(command("apk -vv info | grep #{package}").exit_status).to eq(0)
+    end
+  end
+end


### PR DESCRIPTION
[Auto-generate SSLs for all internal components](https://www.pivotaltracker.com/story/show/111428758)

What
----

We want to generate the certificates for all the components, signed by a CA which is trusted by all the related VMs.

For that, we will use [certstrap](https://github.com/square/certstrap/) tooling to simplify management of the certificates.
In the concourse job pipelines we will also interact with S3 using the script `s3init.sh`, so we must include `curl` and `ca-certificates`.

how to test:
-----------

Travis tests should execute the spec added in this PR and pass .
```
rake build:certstrap spec:certstrap
```

Notes
-----

A docker hub automated build must be setup with this Dockerfile.

The PR https://github.com/alphagov/paas-cf/pull/92 must be updated to use
the new container

Who?
----

Anyone but @keymon or @mtekel