### PR TITLE
[#112503901] Create cf-cli image

### DIFF
--- a/cf-cli/Dockerfile
+++ b/cf-cli/Dockerfile
@@ -1,0 +1,3 @@
+FROM golang:1.5.3-wheezy
+
+RUN curl -L 'https://cli.run.pivotal.io/stable?release=linux64-binary&version=6.15.0' | tar -zx -C /usr/local/bin

--- a/cf-cli/README.md
+++ b/cf-cli/README.md
@@ -1,0 +1,17 @@
+Includes the Cloudfoundry CLI (`cf`), as well as a Go 1.5 runtime
+
+Based on the [golang](https://hub.docker.com/_/golang/) image.
+
+## Build locally
+
+```
+$ cd cf-cli
+$ docker build -t cf-cli .
+```
+
+## Run
+
+```
+docker run -i -t cf-cli go version
+docker run -i -t cf-cli cf --version
+```

--- a/cf-cli/cf-cli_spec.rb
+++ b/cf-cli/cf-cli_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+require 'docker'
+require 'serverspec'
+
+GO_VERSION="1.5.3"
+CF_CLI_VERSION="6.15.0"
+
+describe "cf-cli image" do
+  before(:all) {
+    set :docker_image, find_image_id('cf-cli:latest')
+  }
+
+  it "has the expected version of Go" do
+    expect(
+      command("go version").stdout
+    ).to match(/go version go#{GO_VERSION}/)
+  end
+
+  it "has the expected version of the CF CLI" do
+    expect(
+      command("cf --version").stdout
+    ).to match(/cf version #{CF_CLI_VERSION}/)
+  end
+end

--- a/curl-ssl/README.md
+++ b/curl-ssl/README.md
@@ -7,7 +7,7 @@ Based on [alpine](https://hub.docker.com/_/alpine/) image.
 ## Build locally
 
 ```
-$ cd bosh-init
+$ cd curl-ssl
 $ docker build -t curl-ssl .
 ```
 


### PR DESCRIPTION
This contains the CF CLI, and a Go runtime. This will be used to run the
acceptance tests in concourse.