### PR TITLE
[#112503901] Test for curl in cf-cli container

### DIFF
--- a/cf-cli/cf-cli_spec.rb
+++ b/cf-cli/cf-cli_spec.rb
@@ -21,4 +21,11 @@ describe "cf-cli image" do
       command("cf --version").stdout
     ).to match(/cf version #{CF_CLI_VERSION}/)
   end
+
+  it "has curl available" do
+    # Needed by the cf acceptance-test helpers
+    expect(
+      command("curl --version").exit_status
+    ).to eq(0)
+  end
 end


### PR DESCRIPTION
The [CF acceptance-test helpers](https://github.com/cloudfoundry-incubator/cf-test-helpers) depend on curl, so we should verify it's presence in the container.