### PR TITLE
[#112503901] Add godep to cf-acceptance-tests container

### DIFF
--- a/cf-acceptance-tests/Dockerfile
+++ b/cf-acceptance-tests/Dockerfile
@@ -1,3 +1,5 @@
 FROM golang:1.5.3-wheezy
 
 RUN curl -L 'https://cli.run.pivotal.io/stable?release=linux64-binary&version=6.15.0' | tar -zx -C /usr/local/bin
+
+RUN go get github.com/tools/godep

--- a/cf-acceptance-tests/README.md
+++ b/cf-acceptance-tests/README.md
@@ -6,6 +6,7 @@ helpers](https://github.com/cloudfoundry-incubator/cf-test-helpers):
 * Go 1.5 compiler
 * `cf` CLI
 * `curl`
+* [`godep`](github.com/tools/godep)
 
 Based on the [golang](https://hub.docker.com/_/golang/) image.
 

--- a/cf-acceptance-tests/cf-acceptance-tests_spec.rb
+++ b/cf-acceptance-tests/cf-acceptance-tests_spec.rb
@@ -16,6 +16,13 @@ describe "cf-acceptance-tests image" do
     ).to match(/go version go#{GO_VERSION}/)
   end
 
+  it "has godep available" do
+    expect(
+      command("godep version").exit_status
+    ).to eq(0)
+
+  end
+
   it "has the expected version of the CF CLI" do
     expect(
       command("cf --version").stdout


### PR DESCRIPTION
So that we can fetch the dependencies at runtime instead of vendoring them.