### PR TITLE
Bump bosh-aws-cpi release to 44.

### DIFF
--- a/bosh-init/Dockerfile
+++ b/bosh-init/Dockerfile
@@ -13,8 +13,8 @@ RUN apt-get install -y wget
 RUN wget -q -O /usr/local/bin/bosh-init --no-check-certificate ${BOSH_INIT_URL}
 RUN chmod +x /usr/local/bin/bosh-init
 
-ENV BOSH_AWS_CPI_URL https://bosh.io/d/github.com/cloudfoundry-incubator/bosh-aws-cpi-release?v=36
-ENV BOSH_AWS_CPI_CHECKSUM db2a6c6cdd5ff9f77bf083e10118fa72e1f5e181
+ENV BOSH_AWS_CPI_URL https://bosh.io/d/github.com/cloudfoundry-incubator/bosh-aws-cpi-release?v=44
+ENV BOSH_AWS_CPI_CHECKSUM a1fe03071e8b9bf1fa97a4022151081bf144c8bc
 
 COPY bosh_init_cache /tmp/bosh_init_cache/
 RUN /tmp/bosh_init_cache/seed_bosh_init_cache.sh && \


### PR DESCRIPTION
# What

In this PR we are raising the version of bosh_aws_cpi that includes a fix for max retries for calls to AWS. 

bosh-aws-cpi-release v 44 exposes AWS SDK retry option (max_retries) with default of 2

Reference [Changelog](https://github.com/cloudfoundry-incubator/bosh-aws-cpi-release/releases/tag/v44)

This PR should be merged before https://github.com/alphagov/paas-cf/pull/107

# How to test

Use bosh-init container do deploy microbosh and check whether you are getting any 'Rate limit exceeded' errors. You need to modify concourse/pipelines/create-microbosh.yml and add #112411703-bump-bosh-aws-cpi-release tag to the bosh-init contaier. For instance:

```image: docker:///governmentpaas/bosh-init#112411703-bump-bosh-aws-cpi-release```

# Who can test
Anyone but @actionjack or @combor