### PR TITLE
[#112908839] Workflow for Bosh SSH

### DIFF
--- a/bosh-cli/Dockerfile
+++ b/bosh-cli/Dockerfile
@@ -1,0 +1,5 @@
+FROM ruby:2.2-slim
+
+RUN gem install bosh_cli -v 1.3192.0 --no-rdoc --no-ri
+RUN apt-get update && apt-get install -y openssh-client
+

--- a/bosh-cli/README.md
+++ b/bosh-cli/README.md
@@ -1,0 +1,20 @@
+Container for running Bosh SSH.
+
+
+* `BOSH` CLI
+* `SSH`
+
+Based on the [ruby:slim](https://hub.docker.com/_/ruby/) image.
+
+## Build locally
+
+```
+$ cd bosh-cli
+$ docker build -t bosh-cli .
+```
+
+## Run
+
+```
+docker run -i -t bosh-cli bosh --version
+```

--- a/bosh-cli/bosh-cli_spec.rb
+++ b/bosh-cli/bosh-cli_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+require 'docker'
+require 'serverspec'
+
+BOSH_CLI_VERSION="1.3192.0"
+
+describe "bosh-cli image" do
+  before(:all) {
+    set :docker_image, find_image_id('bosh-cli:latest')
+  }
+
+  it "has the expected version of the Bosh CLI" do
+    expect(
+      command("bosh --version").stdout.strip
+    ).to eq("BOSH #{BOSH_CLI_VERSION}")
+  end
+
+  it "has ssh available" do
+    expect(
+      command("ssh -V").exit_status
+    ).to eq(0)
+  end
+end


### PR DESCRIPTION
#What 

The bosh-resource container lacks the SSH binary, meaning that the 'bosh ssh' command does not work. This PR adds a new container for bosh-cli which has both BOSH and SSH commands installed.

# How to test

Follow the instructions in the README.md

# Who can review this PR

Anyone except @alext or myself.