### PR TITLE
[#112908839] Update bosh-cli openssl version.

### DIFF
--- a/bosh-cli/Dockerfile
+++ b/bosh-cli/Dockerfile
@@ -1,5 +1,5 @@
-FROM ruby:2.2-slim
+FROM ruby:2.2-alpine
 
 RUN gem install bosh_cli -v 1.3192.0 --no-rdoc --no-ri
-RUN apt-get update && apt-get install -y openssh-client
 
+RUN apk add --update openssh-client && rm -rf /var/cache/apk/*

--- a/bosh-cli/bosh-cli_spec.rb
+++ b/bosh-cli/bosh-cli_spec.rb
@@ -20,4 +20,19 @@ describe "bosh-cli image" do
       command("ssh -V").exit_status
     ).to eq(0)
   end
+
+  it "has a new enough version of openssl available" do
+    # See https://github.com/nahi/httpclient/blob/v2.7.1/lib/httpclient/ssl_config.rb#L441-L452
+    # (httpclient is a dependency of bosh_cli)
+    # With an older version of openssl, bosh_cli spits out warnings.
+    cmd = command("openssl version")
+    expect(cmd.exit_status).to eq(0)
+
+    ssl_version_str = cmd.stdout.strip
+    if ssl_version_str.start_with?('OpenSSL 1.0.1')
+      expect(ssl_version_str).to be >= 'OpenSSL 1.0.1p'
+    else
+      expect(ssl_version_str).to be >= 'OpenSSL 1.0.2d'
+    end
+  end
 end


### PR DESCRIPTION
httpclient (which is a dependency of bosh-cli) has a [check for the
openssl version](https://github.com/nahi/httpclient/blob/v2.7.1/lib/httpclient/ssl_config.rb#L441-L452) to ensure it includes fixes for a vulnerability.
Versions below this cause it to emit warnings.

Because debian backports security fixes instead of upgrading openssl,
these warnings are triggered here, even though openssl is no longer
vulnerable.

Digging further, the CVE mentioned in the comment in httpclient
specifies that the only versions affected are 1.0.1n, 1.0.1o, 1.0.2b and
1.0.2c, so the httpclient check identifies non-vulnerable versions as
vulnerable.

To work around this, we've switched the bosh-cli container to be based
on alpine, which includes the newer versions of openssl.