### PR TITLE
[#110652158] Add `file` utility to bosh-cli container.

### DIFF
--- a/bosh-cli/Dockerfile
+++ b/bosh-cli/Dockerfile
@@ -2,4 +2,4 @@ FROM ruby:2.2-alpine
 
 RUN gem install bosh_cli -v 1.3192.0 --no-rdoc --no-ri
 
-RUN apk add --update openssh-client && rm -rf /var/cache/apk/*
+RUN apk add --update openssh-client file && rm -rf /var/cache/apk/*

--- a/bosh-cli/bosh-cli_spec.rb
+++ b/bosh-cli/bosh-cli_spec.rb
@@ -15,6 +15,12 @@ describe "bosh-cli image" do
     ).to eq("BOSH #{BOSH_CLI_VERSION}")
   end
 
+  it "has `file` available" do
+    expect(
+      command("file --version").exit_status
+    ).to eq(0)
+  end
+
   it "has ssh available" do
     expect(
       command("ssh -V").exit_status


### PR DESCRIPTION
Without this, we are seeing warnings from `bosh upload relase` saying
"sh: file: not found". Despite this, the bosh upload seems to still
work.

Given this is evidently a dependency of the bosh-cli it seems better
that we include it.

Came across this while looking at making the release upload process
deal with more than one version of a release.