### PR TITLE
[#114193485] Add terraform container from other old repository and enable postgresql

### DIFF
--- a/terraform/Dockerfile
+++ b/terraform/Dockerfile
@@ -1,0 +1,19 @@
+FROM alpine
+ENV PATH $PATH:/usr/local/bin
+ENV TERRAFORM_VER 0.6.10
+ENV TERRAFORM_ZIP terraform_${TERRAFORM_VER}_linux_amd64.zip
+ENV BINARY_WHITELIST \
+  terraform \
+  terraform-provider-aws \
+  terraform-provider-null \
+  terraform-provider-template \
+  terraform-provider-tls \
+  terraform-provisioner-file \
+  terraform-provisioner-local-exec \
+  terraform-provisioner-remote-exec
+
+RUN apk update && apk add openssl openssh ca-certificates
+RUN set -ex \
+       && wget https://releases.hashicorp.com/terraform/${TERRAFORM_VER}/${TERRAFORM_ZIP} -O /tmp/${TERRAFORM_ZIP} \
+       && unzip /tmp/${TERRAFORM_ZIP} -d /usr/local/bin ${BINARY_WHITELIST} \
+       && rm /tmp/${TERRAFORM_ZIP}

--- a/terraform/Dockerfile
+++ b/terraform/Dockerfile
@@ -8,6 +8,7 @@ ENV BINARY_WHITELIST \
   terraform-provider-null \
   terraform-provider-template \
   terraform-provider-tls \
+  terraform-provider-postgresql \
   terraform-provisioner-file \
   terraform-provisioner-local-exec \
   terraform-provisioner-remote-exec

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,0 +1,24 @@
+[![Build Status](https://travis-ci.org/alphagov/paas-docker-terraform.svg)](https://travis-ci.org/alphagov/paas-docker-terraform)
+# docker-terraform
+
+This container allows you to run Terraform inside a Docker container.
+
+## How to run and build
+
+- ```docker build -t terraform .```
+
+## How to run it
+
+```
+docker run -ti terraform terraform
+```
+
+## Container size and binary whitelist
+
+The Terraform installation is quite large; 30~ provider and provisioner
+binaries at 10~20M each. In order to reduce the size of the final container
+we only install the providers and provisioners that we expect to use. A list
+of these is maintained in the [Dockerfile](Dockerfile). We don't expect to
+need to do this in the future if [hashicorp/terraform#4233][] is solved.
+
+[hashicorp/terraform#4233]: https://github.com/hashicorp/terraform/issues/4233

--- a/terraform/terraform_spec.rb
+++ b/terraform/terraform_spec.rb
@@ -1,0 +1,45 @@
+require 'spec_helper'
+require 'docker'
+require 'serverspec'
+
+describe "Terraform image" do
+  before(:all) {
+    set :docker_image, find_image_id('terraform:latest')
+  }
+
+  it "installs the Alpine linux" do
+    expect(file("/etc/alpine-release")).to be_file
+  end
+
+  it "installs Root Certificates" do
+    expect(file("/usr/share/ca-certificates/mozilla/GlobalSign_Root_CA.crt")).to be_file
+  end
+
+  it "checks if terraform binary is executable" do
+    expect(file("/usr/local/bin/terraform")).to be_mode 755
+  end
+
+  it "has the Terraform version 0.6.10" do
+    expect(terraform_version).to include("Terraform v0.6.10")
+  end
+
+  def terraform_version
+    command("terraform version").stdout.strip
+  end
+
+  it "installs SSH" do
+    expect(ssh_version).to include("OpenSSH")
+  end
+
+  def ssh_version
+    command("ssh -V").stderr.strip
+  end
+
+  it "should not have binary directory larger than 200M" do
+    expect(binaries_size).to be < 200
+  end
+
+  def binaries_size
+    Integer(command("du -m /usr/local/bin").stdout.split.first)
+  end
+end

--- a/terraform/terraform_spec.rb
+++ b/terraform/terraform_spec.rb
@@ -8,6 +8,7 @@ REQUIRED_BINARIES = %w{
   terraform-provider-null
   terraform-provider-template
   terraform-provider-tls
+  terraform-provider-postgresql
   terraform-provisioner-file
   terraform-provisioner-local-exec
   terraform-provisioner-remote-exec


### PR DESCRIPTION
What
----

We want to be able to create roles and DBs in postgres using terraform to create
the DBs for the RDS based CF databases.

As we add this change, we will import the separated repository
in https://github.com/alphagov/paas-docker-terraform to
this repository, as this is where we are implementing all the containers.

Context
-------

 * I want to import the code and history from https://github.com/alphagov/paas-docker-terraform
 * and include the postgres provider

How to test?
------------

As usual in this repo, by travis or:

```
rvm use --create 2.2.2@containers
bundle install
bundle exec rake
```

Who?
----

Anyone but @keymon