### PR TITLE
[#114193485] Create psql docker container

### DIFF
--- a/psql/Dockerfile
+++ b/psql/Dockerfile
@@ -1,0 +1,5 @@
+FROM alpine:3.3
+
+ENV PACKAGES "postgresql-client=9.4.6-r0"
+
+RUN apk add --update $PACKAGES && rm -rf /var/cache/apk/*

--- a/psql/README.md
+++ b/psql/README.md
@@ -1,0 +1,16 @@
+Provides *psql* Postgres client.
+
+Based on [alpine](https://hub.docker.com/_/alpine/) image.
+
+## Build locally
+
+```
+$ cd psql
+$ docker build -t psql .
+```
+
+## Run
+
+```
+docker run psql psql --version
+```

--- a/psql/psql_spec.rb
+++ b/psql/psql_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+require 'docker'
+require 'serverspec'
+
+PSQL_PACKAGE = 'postgresql-client'
+PSQL_VERSION = '9.4.6'
+PSQL_PACKAGE_VERSION = PSQL_VERSION + '-r0'
+
+describe "psql image" do
+  before(:all) {
+    set :docker_image, find_image_id('psql:latest')
+  }
+
+  it "installs the right version of Alpine" do
+    expect(os_version).to include("Alpine Linux 3.3")
+  end
+
+  def os_version
+    command("cat /etc/issue | head -1").stdout
+  end
+
+  it "installs required package" do
+    expect(command("apk info #{PSQL_PACKAGE}").stdout.strip).to \
+      include("#{PSQL_PACKAGE}-#{PSQL_PACKAGE_VERSION}")
+  end
+
+  it "can run psql" do
+    expect(command('psql --version').exit_status).to eq(0)
+  end
+
+  it "has the right version" do
+    expect(command("psql --version").stdout.strip).to include(PSQL_VERSION)
+  end
+
+end


### PR DESCRIPTION
# What
Create psql Postgres client container so we can run psql commands from Concourse. This is necessary to set up the CF RDS database.
Contains test and README.

# How to review
* build: `rake build:psql`
* test: `rake spec:psql`
* run: `docker run psql psql --version`

# Who can review
Anyone but @mtekel or me