### PR TITLE
[#113824903] Bump terraform to 0.6.12

### DIFF
--- a/terraform/Dockerfile
+++ b/terraform/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine
 ENV PATH $PATH:/usr/local/bin
-ENV TERRAFORM_VER 0.6.10
+ENV TERRAFORM_VER 0.6.12
 ENV TERRAFORM_ZIP terraform_${TERRAFORM_VER}_linux_amd64.zip
 ENV BINARY_WHITELIST \
   terraform \

--- a/terraform/Dockerfile
+++ b/terraform/Dockerfile
@@ -13,7 +13,7 @@ ENV BINARY_WHITELIST \
   terraform-provisioner-local-exec \
   terraform-provisioner-remote-exec
 
-RUN apk update && apk add openssl openssh ca-certificates
+RUN apk add --update openssl openssh-client ca-certificates && rm -rf /var/cache/apk/*
 RUN set -ex \
        && wget https://releases.hashicorp.com/terraform/${TERRAFORM_VER}/${TERRAFORM_ZIP} -O /tmp/${TERRAFORM_ZIP} \
        && unzip /tmp/${TERRAFORM_ZIP} -d /usr/local/bin ${BINARY_WHITELIST} \

--- a/terraform/terraform_spec.rb
+++ b/terraform/terraform_spec.rb
@@ -27,10 +27,6 @@ describe "Terraform image" do
     expect(file("/usr/share/ca-certificates/mozilla/GlobalSign_Root_CA.crt")).to be_file
   end
 
-  it "checks if terraform binary is executable" do
-    expect(file("/usr/local/bin/terraform")).to be_mode 755
-  end
-
   it "installs all the whitelisted binaries" do
     command("echo $BINARY_WHITELIST").stdout.split.each { |f|
       expect(file("/usr/local/bin/#{f}")).to be_mode 755
@@ -45,27 +41,21 @@ describe "Terraform image" do
     end
   }
 
-  it "has the Terraform version 0.6.10" do
-    expect(terraform_version).to include("Terraform v0.6.10")
-  end
-
-  def terraform_version
-    command("terraform version").stdout.strip
+  it "has the expected Terraform version" do
+    expect(
+      command("terraform version").stdout
+    ).to include("Terraform v0.6.10")
   end
 
   it "installs SSH" do
-    expect(ssh_version).to include("OpenSSH")
-  end
-
-  def ssh_version
-    command("ssh -V").stderr.strip
+    expect(
+      command("ssh -V").stderr.strip
+    ).to include("OpenSSH")
   end
 
   it "should not have binary directory larger than 200M" do
-    expect(binaries_size).to be < 200
-  end
-
-  def binaries_size
-    Integer(command("du -m /usr/local/bin").stdout.split.first)
+    expect(
+      Integer(command("du -m /usr/local/bin").stdout.split.first)
+    ).to be < 200
   end
 end

--- a/terraform/terraform_spec.rb
+++ b/terraform/terraform_spec.rb
@@ -44,7 +44,7 @@ describe "Terraform image" do
   it "has the expected Terraform version" do
     expect(
       command("terraform version").stdout
-    ).to include("Terraform v0.6.10")
+    ).to include("Terraform v0.6.12")
   end
 
   it "installs SSH" do


### PR DESCRIPTION
There's an issue with earlier versions when handling a security group
with multiple ingress blocks for the same port range. It results in
terraform updating the resource on every run. This is no longer the case
with 0.6.12. See https://github.com/hashicorp/terraform/issues/5301#issuecomment-188746760 for details of this issue.

See also the related paas-cf PR - https://github.com/alphagov/paas-cf/pull/123

## How to review.

This is best reviewed in conjunction with the above paas-cf PR. See notes there for details.

## Who can review

Anyone but mysql.