### PR TITLE
[#114186797] Add unzip command to cf-acceptance-tests container

### DIFF
--- a/cf-acceptance-tests/Dockerfile
+++ b/cf-acceptance-tests/Dockerfile
@@ -1,5 +1,8 @@
 FROM golang:1.5.3-wheezy
 
 RUN curl -L 'https://cli.run.pivotal.io/stable?release=linux64-binary&version=6.15.0' | tar -zx -C /usr/local/bin
+RUN apt-get update \
+      && apt-get install -y --no-install-recommends unzip \
+      && rm -rf /var/lib/apt/lists/*
 
 RUN go get github.com/tools/godep

--- a/cf-acceptance-tests/cf-acceptance-tests_spec.rb
+++ b/cf-acceptance-tests/cf-acceptance-tests_spec.rb
@@ -35,4 +35,11 @@ describe "cf-acceptance-tests image" do
       command("curl --version").exit_status
     ).to eq(0)
   end
+
+  it "has unzip available" do
+    # Needed by the cf acceptance-test helpers
+    expect(
+      command("unzip -v").exit_status
+    ).to eq(0)
+  end
 end


### PR DESCRIPTION
[#114186797 Run smoke tests and acceptance tests in concourse task rather than errand](https://www.pivotaltracker.com/story/show/114186797)

What
----

We want to run the cf-acceptance-tests on concourse directly, but as they
[call unzip command](https://github.com/cloudfoundry/cf-acceptance-tests/blob/e5e7b4726f61f9e66da43c1daf0151d6b4492be1/v3/package_test.go#L75),
we need to install the package in the container.


How to test this
----------------

As usual, follow README instructions and:

```
rake build:cf-acceptance-tests spec:cf-acceptance-tests
```

Travis tests should be OK.

Who?
----

Anyone but @keymon