### PR TITLE
[#113749465] Add container with cf-cli andd tools for deploy

### DIFF
--- a/cf-cli/Dockerfile
+++ b/cf-cli/Dockerfile
@@ -1,0 +1,9 @@
+FROM debian:wheezy
+
+ENV PACKAGES unzip curl ca-certificates git
+
+RUN apt-get update \
+      && apt-get install -y --no-install-recommends $PACKAGES \
+      && rm -rf /var/lib/apt/lists/*
+RUN curl -L 'https://cli.run.pivotal.io/stable?release=linux64-binary&version=6.15.0' | tar -zx -C /usr/local/bin
+

--- a/cf-cli/README.md
+++ b/cf-cli/README.md
@@ -1,0 +1,26 @@
+Container for running CloudFoundry client.
+
+It includes some other packages commonly used when deploying CF apps:
+
+* `cf` CLI
+* `curl`
+* `unzip`
+* `git`
+
+Based on the [wheezy](https://hub.docker.com/_/debian/) image.
+
+## Build locally
+
+```
+$ cd cf-cli
+$ docker build -t cf-cly .
+```
+
+## Run
+
+```
+docker run -i -t cf-cli cf --version
+docker run -i -t cf-cli curl --version
+docker run -i -t cf-cli unzip -v
+docker run -i -t cf-cli git --version
+```

--- a/cf-cli/cf-acceptance-tests_spec.rb
+++ b/cf-cli/cf-acceptance-tests_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+require 'docker'
+require 'serverspec'
+
+CF_CLI_VERSION="6.15.0"
+
+describe "cf-cli image" do
+  before(:all) {
+    set :docker_image, find_image_id('cf-cli:latest')
+  }
+
+  it "has the expected version of the CF CLI" do
+    expect(
+      command("cf --version").stdout
+    ).to match(/cf version #{CF_CLI_VERSION}/)
+  end
+
+  it "has curl available" do
+    expect(
+      command("curl --version").exit_status
+    ).to eq(0)
+  end
+
+  it "has unzip available" do
+    expect(
+      command("unzip -v").exit_status
+    ).to eq(0)
+  end
+
+  it "has git available" do
+    expect(
+      command("git --version").exit_status
+    ).to eq(0)
+  end
+end


### PR DESCRIPTION
[#113749465 Make Cloud Foundry Metrics Available](https://www.pivotaltracker.com/story/show/113749465)

What?
-----

We need a container to be able to deploy CF apps in a task. We also need some other tools
like curl, unzip and git to be able to download, uncompress or clone/checkout dependencies.

Container with CF client command and some other tools to help deploying
apps in cloudfoundry: curl, git, unzip.

Based on Debian wheezy, as the distributed binary cf-cli depends on the
libc of a Debian like linux distro (alpine won't work).

Dependencies
-------------------

This is required before https://github.com/alphagov/paas-cf/pull/139 is merged.

Test
----

Travis should run the tests and end successfull.

To run tests locally: `rake build:cf-cli spec:cf-cli`

Who?
----

Anyone but @keymon