### PR TITLE
[#115258555] Use the latest spruce 1.1.2 from release

### DIFF
--- a/spruce/Dockerfile
+++ b/spruce/Dockerfile
@@ -1,11 +1,11 @@
-FROM golang:1.5.1-alpine
+FROM alpine:3.3
 
-ENV SPRUCE_VERSION 0.13.0
+ENV SPRUCE_VERSION 1.1.2
 
-RUN apk add --update git \
-  && go get -d github.com/geofffranks/spruce \
-  && cd ${GOPATH}/src/github.com/geofffranks/spruce \
-  && git checkout v${SPRUCE_VERSION} \
-  && go install \
-  && apk del git \
+ENV PACKAGES "curl openssl ca-certificates"
+
+RUN apk add --update $PACKAGES \
+  && curl -f -L https://github.com/geofffranks/spruce/releases/download/v$SPRUCE_VERSION/spruce-linux-amd64 > /usr/local/bin/spruce \
+  && chmod +x /usr/local/bin/spruce \
+  && apk del $PACKAGES \
   && rm -rf /var/cache/apk/*

--- a/spruce/spruce_spec.rb
+++ b/spruce/spruce_spec.rb
@@ -2,8 +2,8 @@ require 'spec_helper'
 require 'docker'
 require 'serverspec'
 
-SPRUCE_BIN = "/go/bin/spruce"
-SPRUCE_VERSION = "0.13.0"
+SPRUCE_BIN = "/usr/local/bin/spruce"
+SPRUCE_VERSION = "1.1.2"
 
 describe "spruce image" do
   before(:all) {
@@ -11,7 +11,7 @@ describe "spruce image" do
   }
 
   it "installs the right version of Alpine Linux" do
-    expect(os_version).to include("Alpine Linux 3.2")
+    expect(os_version).to include("Alpine Linux 3.3")
   end
 
   def os_version


### PR DESCRIPTION
What?
----

We have been using the version 0.13.0 of spruce, but compiling it
in the Dockerfile because the release binary version did link to
the debian/ubuntu libc. We were not pinning the git commit of the
spruce code.

But the upstream project has some changes that makes fail the build,
probably new dependencies added which require the use of godep.

As since https://github.com/geofffranks/spruce/issues/83 the binary
in the releases is OK and can work in a plain alpine, we can create
a container pulling the binary release. This will simplify our
container, make it smaller and pin the version number.

How to test this?
----------------

Travis should run OK and you can run the tests with:

```
rake build:spruce spec:spruce
```

who?
----

anyone but @keymon or @henrytk