### PR TITLE
[#115258555] Fix spruce container 0.13.0

### DIFF
--- a/spruce/Dockerfile
+++ b/spruce/Dockerfile
@@ -6,6 +6,7 @@ RUN apk add --update git \
   && go get -d github.com/geofffranks/spruce \
   && cd ${GOPATH}/src/github.com/geofffranks/spruce \
   && git checkout v${SPRUCE_VERSION} \
+  && export GOPATH=$(pwd)/Godeps/_workspace:$GOPATH \
   && go install \
   && apk del git \
   && rm -rf /var/cache/apk/*


### PR DESCRIPTION
# What
Story: [Fix the paas-docker-cloudfoundry-tools build](https://www.pivotaltracker.com/story/show/115258555)
It looks like the spruce tag we are pinning to in the Docker file
was modified as it doesn't compile because of a failed dependency.
As the dependencies are vendored, a simple fix is to add the spruce
repository to $GOPATH.

# How to test
* Load the ruby environment related to the Gemfile
* `rake build:spruce`
* `rake spec:spruce`
* run:

```
$ docker run spruce spruce --version
spruce - Version 0.13.0 (master)
```

# How can review
Anyone but @keymon or me