### PR TITLE
[#114000923] Add fly-cli container to update pipelines

### DIFF
--- a/fly-cli/Dockerfile
+++ b/fly-cli/Dockerfile
@@ -1,0 +1,10 @@
+FROM alpine:3.3
+
+ENV PACKAGES bash ruby curl ca-certificates
+ENV FLY_CLI_URL http://ci.concourse.ci/api/v1/cli?arch=amd64&platform=linux
+
+RUN apk add --update $PACKAGES \
+    && rm -rf /var/cache/apk/* \
+    && curl -f -L "${FLY_CLI_URL}" > /usr/local/bin/fly \
+    && chmod +x /usr/local/bin/fly
+

--- a/fly-cli/README.md
+++ b/fly-cli/README.md
@@ -1,0 +1,20 @@
+Container for running Concourse fly client.
+
+It includes the tooling required to update the upstream pipelines
+
+* `fly` concourse CLI
+* `curl`
+* `ruby` and `bash`
+
+## Build locally
+
+```
+$ cd fly-cli
+$ docker build -t fly-cly .
+```
+
+## Run
+
+```
+docker run -i -t fly-cli fly --help
+```

--- a/fly-cli/fly-cli_spec.rb
+++ b/fly-cli/fly-cli_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+require 'docker'
+require 'serverspec'
+
+describe "fly-cli image" do
+  before(:all) {
+    set :docker_image, find_image_id('fly-cli:latest')
+  }
+
+  it "installs the right version of Alpine" do
+    expect(os_version).to include("Alpine Linux 3.3")
+  end
+
+  def os_version
+    command("cat /etc/issue | head -1").stdout
+  end
+
+  it "has curl available" do
+    expect(
+      command("curl --version").exit_status
+    ).to eq(0)
+  end
+
+  it "has fly available" do
+    expect(
+      command("fly -v").exit_status
+    ).to eq(0)
+  end
+end


### PR DESCRIPTION
[#114000923 self-updating pipelines](https://www.pivotaltracker.com/story/show/114000923)

What
----

We want to be able to update concourse pipelines from concourse itself, using
the same scripts that we use to setup the pipelines.

Add a fly-cli container to run jobs that update concourse pipelines.
We also require bash, curl, and ruby to support the pipeline scripts.

How to test
-----------

As usual: `make build:fly-cli spec:fly-cli` and travis should success.

Who?
----

Anyone but @keymon or @saliceti