### PR TITLE
[#114000923] Add ruby-slim container to run deployment related scripts

### DIFF
--- a/ruby-slim/Dockerfile
+++ b/ruby-slim/Dockerfile
@@ -1,0 +1,8 @@
+FROM ruby:2.2-slim
+
+ENV PACKAGES unzip git
+
+RUN apt-get update \
+      && apt-get install -y --no-install-recommends $PACKAGES \
+      && rm -rf /var/lib/apt/lists/*
+

--- a/ruby-slim/README.md
+++ b/ruby-slim/README.md
@@ -1,0 +1,25 @@
+Container for running deployment scripts based on ruby.
+
+It includes some other packages commonly used when deploying CF apps:
+
+* `ruby` and `curl`: Included on `ruby-slim`
+* `unzip`
+* `git`
+
+Based on the [wheezy](https://hub.docker.com/_/debian/) image.
+
+## Build locally
+
+```
+$ cd ruby-slim
+$ docker build -t ruby-slim .
+```
+
+## Run
+
+```
+docker run -i -t ruby-slim ruby -v
+docker run -i -t ruby-slim curl --version
+docker run -i -t ruby-slim unzip -v
+docker run -i -t ruby-slim git --version
+```

--- a/ruby-slim/ruby-slim_spec.rb
+++ b/ruby-slim/ruby-slim_spec.rb
@@ -1,0 +1,39 @@
+require 'spec_helper'
+require 'docker'
+require 'serverspec'
+
+describe "ruby-slim image" do
+  before(:all) {
+    set :docker_image, find_image_id('ruby-slim:latest')
+  }
+
+  it "has ruby available" do
+    expect(
+      command("ruby -v").stdout
+    ).to match(/ruby 2\.2/)
+  end
+
+  it "has curl available" do
+    expect(
+      command("curl --version").stdout
+    ).to match(/curl 7\.38/)
+  end
+
+  it "has unzip available" do
+    expect(
+      command("unzip -v").stdout
+    ).to match(/UnZip 6.*by Debian.*Original by Info-ZIP/)
+  end
+
+  it "has git available" do
+    expect(
+      command("git --version").stdout
+    ).to match(/git version 2/)
+  end
+
+  it "has bash available" do
+    expect(
+      command("bash --version").stdout
+    ).to match(/GNU bash, version 4\.3/)
+  end
+end


### PR DESCRIPTION
[#114000923 self-updating pipelines](https://www.pivotaltracker.com/story/show/114000923)

What
----

We want to be able to update concourse pipelines from concourse itself, using
the same scripts that we use to setup the pipelines.

Add a ruby-slim container to run jobs that update concourse pipelines.
We require bash, curl, ruby, unzip and git to support the pipeline scripts.

How to test
-----------

As usual: `make build:ruby-slim spec:ruby-slim` and travis should success.

Who?
----

Anyone but @keymon