### PR TITLE
[#114000923] Add self-update-pipelines container to run update pipelines related scripts

### DIFF
--- a/self-update-pipelines/Dockerfile
+++ b/self-update-pipelines/Dockerfile
@@ -1,0 +1,8 @@
+FROM ruby:2.2-slim
+
+ENV PACKAGES make
+
+RUN apt-get update \
+      && apt-get install -y --no-install-recommends $PACKAGES \
+      && rm -rf /var/lib/apt/lists/*
+

--- a/self-update-pipelines/README.md
+++ b/self-update-pipelines/README.md
@@ -1,0 +1,25 @@
+Container for running the self-update pipeline task which runs
+the setup pipeline scipts.
+
+This includes all the software for this task to run.
+
+* `ruby` and `curl`: Included on `ruby:slim`
+* `make`
+
+Based on the [wheezy](https://hub.docker.com/_/ruby/) image.
+
+## Build locally
+
+```
+$ cd self-update-pipelines
+$ docker build -t self-update-pipelines .
+```
+
+## Run
+
+```
+docker run -i -t self-update-pipelines ruby -v
+docker run -i -t self-update-pipelines curl --version
+docker run -i -t self-update-pipelines bash --version
+docker run -i -t self-update-pipelines make --version
+```

--- a/self-update-pipelines/self-update-pipelines_spec.rb
+++ b/self-update-pipelines/self-update-pipelines_spec.rb
@@ -1,0 +1,34 @@
+require 'spec_helper'
+require 'docker'
+require 'serverspec'
+
+describe "self-update-pipelines image" do
+  before(:all) {
+    set :docker_image, find_image_id('self-update-pipelines:latest')
+  }
+
+  it "has ruby available" do
+    expect(
+      command("ruby -v").stdout
+    ).to match(/ruby 2\.2/)
+  end
+
+  it "has curl available" do
+    expect(
+      command("curl --version").stdout
+    ).to match(/curl 7\.38/)
+  end
+
+  it "has bash available" do
+    expect(
+      command("bash --version").stdout
+    ).to match(/GNU bash, version 4\.3/)
+  end
+
+  it "has make available" do
+    expect(
+      command("make --version").stdout
+    ).to match(/GNU Make 4/)
+  end
+
+end


### PR DESCRIPTION
[#114000923 self-updating pipelines](https://www.pivotaltracker.com/story/show/114000923)

What
----

We want to be able to update concourse pipelines from concourse itself, using
the same scripts that we use to setup the pipelines.

Add a self-update-pipelines container to run jobs which update the pipelines
in concourse using the configuration scripts.
These scripts require bash, curl, ruby and make.


How to test
-----------

As usual: `make build:self-update-pipelines spec:self-update-pipelines` and
travis should success.

Who?
----

Anyone but @keymon