### PR TITLE
Make build rake tasks exit non-zero on error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,8 @@ sudo: required
 services:
   - docker
 
-before_install:
-  - bundle install
+before_script:
   - bundle exec rake build:all
 
 script:
-  - cd ${TRAVIS_BUILD_DIR} && bundle exec rake spec:all
+  - bundle exec rake spec:all

--- a/Rakefile
+++ b/Rakefile
@@ -5,7 +5,7 @@ namespace :build do |ns|
   containers.each { |container|
     desc "Build #{container} image"
     task container.to_sym do
-      system "cd #{container} && docker build -t #{container} ."
+      system "cd #{container} && docker build -t #{container} ." or abort
     end
   }
   desc "Build all containers"


### PR DESCRIPTION
This will give us early feedback on build errors, and make it more obvious what has actually errored.

At present, if a build fails, the rake task doesn't exit non-zero, so everything else continues, and then the tests fail, and it's not easy to see what the actual problem is.

## How to test

Cause one of the image builds to fail (eg by adding a `RUN false` line to the `Dockerfile`). Then run `bundle exec rake build:all`, and verify that it exits non-zero immediately that it encounters the error.

## Who can test

Anyone but myself.