### PR TITLE
[#115318605] Add Git container with SSH support

### DIFF
--- a/git-ssh/Dockerfile
+++ b/git-ssh/Dockerfile
@@ -1,0 +1,5 @@
+FROM alpine:3.3
+
+ENV PACKAGES "git=2.6.4-r0 openssh-client=7.1_p2-r0"
+
+RUN apk add --update $PACKAGES && rm -rf /var/cache/apk/*

--- a/git-ssh/README.md
+++ b/git-ssh/README.md
@@ -1,0 +1,19 @@
+Installs Git with OpenSSH
+
+Git also includes by default curl, OpenSSL and ca-certificates.
+
+Based on [alpine](https://hub.docker.com/_/alpine/) image.
+
+## Build locally
+
+```
+$ cd git-ssh
+$ docker build -t git-ssh .
+```
+
+## Run
+
+```
+docker run git-ssh git --version
+docker run git-ssh ssh -V
+```

--- a/git-ssh/git-ssh_spec.rb
+++ b/git-ssh/git-ssh_spec.rb
@@ -1,0 +1,44 @@
+require 'spec_helper'
+require 'docker'
+require 'serverspec'
+
+PACKAGES = "git openssh-client ca-certificates"
+GIT_VERSION = "2.6.4"
+OPENSSH_VERSION = "7.1p2"
+
+describe "image" do
+  before(:all) {
+    set :docker_image, find_image_id('git-ssh:latest')
+  }
+
+  it "installs the right version of Alpine" do
+    expect(os_version).to include("Alpine Linux 3.3")
+  end
+
+  def os_version
+    command("cat /etc/issue | head -1").stdout
+  end
+
+  it "installs required packages" do
+    PACKAGES.split(' ').each do |package|
+      expect(command("apk -vv info | grep #{package}").exit_status).to eq(0)
+    end
+  end
+
+  it "can run git" do
+    expect(command('git --version').exit_status).to eq(0)
+  end
+
+  it "has the right git version" do
+    expect(command("git --version").stdout.strip).to include(GIT_VERSION)
+  end
+
+  it "can run ssh" do
+    expect(command('ssh -V').exit_status).to eq(0)
+  end
+
+  it "has the right ssh version" do
+    expect(command("ssh -V").stderr.strip).to include(OPENSSH_VERSION)
+  end
+
+end


### PR DESCRIPTION
# What
Story: [Create tags for deploying to staging and prod](https://www.pivotaltracker.com/story/show/115318605)

We need to push to Git using SSH. We avoid the Git resource because we would have to expose the private key. This container is required to run Git within a task.

# How to review

* Build: `rake build:git-ssh`
* Test: `rake spec:git-ssh`
* Play:
```
docker run git-ssh git --version
docker run git-ssh ssh -V
```
# Who can review
Anyone but @mtekel or myself