### PR TITLE
[#115624569] Terraform container includes awscli tools

### DIFF
--- a/terraform/Dockerfile
+++ b/terraform/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.3
+FROM governmentpaas/awscli
 
 ENV PATH $PATH:/usr/local/bin
 ENV TERRAFORM_VER 0.6.13


### PR DESCRIPTION
What?
-----

In order to workaround a some missing features in terraform:

https://github.com/hashicorp/terraform/issues/5778

we want to be able to use a `local_exec` provisioner calling awscli commands.

We don't want to do it in a different task, to avoid spread the configuration
across different files and components. Using awscli from terraform
allows us keep all the related configuration is contained in the terraform
config files.

How to test this?
----------------

```
rake build:terraform spec:teraform
```

Travis should pass.

you can run `docker run -it terraform aws help`


Who?
----

Anyone but @keymon