### PR TITLE
[#115624569] Build terraform from master git repo

### DIFF
--- a/terraform/Dockerfile
+++ b/terraform/Dockerfile
@@ -1,8 +1,7 @@
-FROM alpine:3.3
+FROM golang:1.6-alpine
 
 ENV PATH $PATH:/usr/local/bin
-ENV TERRAFORM_VER 0.6.13
-ENV TERRAFORM_ZIP terraform_${TERRAFORM_VER}_linux_amd64.zip
+ENV TERRAFORM_TAG 9cb08cb229a821753bdba8a6fc8c010767dea6c1
 ENV BINARY_WHITELIST \
   terraform \
   terraform-provider-aws \
@@ -14,8 +13,16 @@ ENV BINARY_WHITELIST \
   terraform-provisioner-local-exec \
   terraform-provisioner-remote-exec
 
-RUN apk add --update openssl openssh-client ca-certificates && rm -rf /var/cache/apk/*
+ENV PACKAGES "openssl openssh-client ca-certificates make bash git"
+
 RUN set -ex \
-       && wget https://releases.hashicorp.com/terraform/${TERRAFORM_VER}/${TERRAFORM_ZIP} -O /tmp/${TERRAFORM_ZIP} \
-       && unzip /tmp/${TERRAFORM_ZIP} -d /usr/local/bin ${BINARY_WHITELIST} \
-       && rm /tmp/${TERRAFORM_ZIP}
+    && apk add --update $PACKAGES \
+    && mkdir -p /go/src/github.com/hashicorp/ \
+    && cd /go/src/github.com/hashicorp/ \
+    && git clone https://github.com/hashicorp/terraform.git \
+    && cd terraform \
+    && git checkout $TERRAFORM_TAG \
+    && make dev \
+    && for file in $BINARY_WHITELIST ; do mv bin/$file /usr/local/bin ; done \
+    && rm -rf /go \
+    && rm -rf /var/cache/apk/*

--- a/terraform/terraform_spec.rb
+++ b/terraform/terraform_spec.rb
@@ -27,12 +27,6 @@ describe "Terraform image" do
     expect(file("/usr/share/ca-certificates/mozilla/GlobalSign_Root_CA.crt")).to be_file
   end
 
-  it "installs all the whitelisted binaries" do
-    command("echo $BINARY_WHITELIST").stdout.split.each { |f|
-      expect(file("/usr/local/bin/#{f}")).to be_mode 755
-    }
-  end
-
   REQUIRED_BINARIES.each { |binary|
     it "required binary '#{binary}' is in path and executable" do
       command_path = command("which #{binary}").stdout.strip

--- a/terraform/terraform_spec.rb
+++ b/terraform/terraform_spec.rb
@@ -38,7 +38,7 @@ describe "Terraform image" do
   it "has the expected Terraform version" do
     expect(
       command("terraform version").stdout
-    ).to include("Terraform v0.6.13")
+    ).to include("Terraform v0.6.15-dev")
   end
 
   it "installs SSH" do


### PR DESCRIPTION
[#115624569 Implement locking for pipelines](https://www.pivotaltracker.com/story/show/115624569)

# What?

We need to start using the resource `aws_iam_user_ssh_key` to be able to upload ssh keys to users to access codecommit.

Until there is not a new release of terraform, we will build it from source

# Test

```
rake build:terraform spec:terraform
```

and travis should pass. Try building your environment using this new image. To do that, update links in the pipeline like this :
```
-        image: docker:///governmentpaas/terraform
+        image: docker:///governmentpaas/terraform#new-tf-build
```

# Who?

Anyone but @keymon or @mtekel 