### PR TITLE
[#115624569] Instal awscli in self-update-pipelines container

### DIFF
--- a/self-update-pipelines/Dockerfile
+++ b/self-update-pipelines/Dockerfile
@@ -1,8 +1,9 @@
 FROM ruby:2.2-slim
 
-ENV PACKAGES make
+ENV AWSCLI_VERSION "1.9.21"
+ENV PACKAGES make python-pip groff less
 
 RUN apt-get update \
       && apt-get install -y --no-install-recommends $PACKAGES \
-      && rm -rf /var/lib/apt/lists/*
-
+      && rm -rf /var/lib/apt/lists/* \
+      && pip install awscli==$AWSCLI_VERSION

--- a/self-update-pipelines/self-update-pipelines_spec.rb
+++ b/self-update-pipelines/self-update-pipelines_spec.rb
@@ -2,6 +2,9 @@ require 'spec_helper'
 require 'docker'
 require 'serverspec'
 
+AWSCLI_BIN = "/usr/local/bin/aws"
+AWSCLI_VERSION = "1.9.21"
+
 describe "self-update-pipelines image" do
   before(:all) {
     set :docker_image, find_image_id('self-update-pipelines:latest')
@@ -31,4 +34,22 @@ describe "self-update-pipelines image" do
     ).to match(/GNU Make 4/)
   end
 
+  it "checks if 'aws' binary exists and is a file" do
+    expect(file(AWSCLI_BIN)).to be_file
+  end
+
+  it "checks if 'aws' binary is executable" do
+    expect(file(AWSCLI_BIN)).to be_mode 755
+  end
+
+  it "has the 'aws' version #{AWSCLI_VERSION}" do
+    def awscli_version
+      command("aws --version").stderr.strip
+    end
+    expect(awscli_version).to match(/aws-cli\/#{AWSCLI_VERSION} /)
+  end
+
+  it "the 'aws help' command works" do
+    expect(command("aws help").stdout.gsub(/\s+/, "\s")).to match(/The AWS Command Line Interface/)
+  end
 end


### PR DESCRIPTION
[#115624569 Implement locking for pipelines](https://www.pivotaltracker.com/story/show/115624569)

What?
---

For the setup of the pool resource for the pipeline locking, we need
to download some objects from S3. We decided use aws cli for this.

Context?
------

In this commit we install awscli from pip in ubuntu.

Test this?
-------

check #14 and #35

Who?
---

Anyone but @keymon