### PR TITLE
[#117021589]  Go version bump to 1.6

### DIFF
--- a/cf-acceptance-tests/Dockerfile
+++ b/cf-acceptance-tests/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.5.3-wheezy
+FROM golang:1.6.0-wheezy
 
 RUN curl -L 'https://cli.run.pivotal.io/stable?release=linux64-binary&version=6.15.0' | tar -zx -C /usr/local/bin
 RUN apt-get update \

--- a/cf-acceptance-tests/cf-acceptance-tests_spec.rb
+++ b/cf-acceptance-tests/cf-acceptance-tests_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'docker'
 require 'serverspec'
 
-GO_VERSION="1.5.3"
+GO_VERSION="1.6"
 CF_CLI_VERSION="6.15.0"
 
 describe "cf-acceptance-tests image" do


### PR DESCRIPTION
# What
Current [vegeta](github.com/tsenart/vegeta) code has been moved to Go 1.6 and fails with earlier Go versions with:
```
 github.com/tsenart/vegeta/lib/attack.go:156: tr.TLSNextProto undefined (type *http.Transport has no field or method TLSNextProto)
```
We need to bump GO version to 1.6

# How to review

run:
```
docker build -t cf-acceptance-tests .
docker run cf-acceptance-tests go version
``` 
and check if go version is 1.6

# Who can review 

Not @keymon or @combor