### PR TITLE
Revert "[#116983391] Bump cf-cli versions to meet reqs for CF v233"

### DIFF
--- a/cf-acceptance-tests/Dockerfile
+++ b/cf-acceptance-tests/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.6.0-wheezy
 
-RUN curl -L 'https://cli.run.pivotal.io/stable?release=linux64-binary&version=6.16.1' | tar -zx -C /usr/local/bin
+RUN curl -L 'https://cli.run.pivotal.io/stable?release=linux64-binary&version=6.15.0' | tar -zx -C /usr/local/bin
 RUN apt-get update \
       && apt-get install -y --no-install-recommends unzip \
       && rm -rf /var/lib/apt/lists/*

--- a/cf-acceptance-tests/cf-acceptance-tests_spec.rb
+++ b/cf-acceptance-tests/cf-acceptance-tests_spec.rb
@@ -3,7 +3,7 @@ require 'docker'
 require 'serverspec'
 
 GO_VERSION="1.6"
-CF_CLI_VERSION="6.16.1"
+CF_CLI_VERSION="6.15.0"
 
 describe "cf-acceptance-tests image" do
   before(:all) {

--- a/cf-cli/Dockerfile
+++ b/cf-cli/Dockerfile
@@ -5,5 +5,5 @@ ENV PACKAGES unzip curl ca-certificates git
 RUN apt-get update \
       && apt-get install -y --no-install-recommends $PACKAGES \
       && rm -rf /var/lib/apt/lists/*
-RUN curl -L 'https://cli.run.pivotal.io/stable?release=linux64-binary&version=6.16.1' | tar -zx -C /usr/local/bin
+RUN curl -L 'https://cli.run.pivotal.io/stable?release=linux64-binary&version=6.15.0' | tar -zx -C /usr/local/bin
 

--- a/cf-cli/cf-acceptance-tests_spec.rb
+++ b/cf-cli/cf-acceptance-tests_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'docker'
 require 'serverspec'
 
-CF_CLI_VERSION="6.16.1"
+CF_CLI_VERSION="6.15.0"
 
 describe "cf-cli image" do
   before(:all) {


### PR DESCRIPTION
Reverts alphagov/paas-docker-cloudfoundry-tools#45, as it seems to make acceptance tests fail