### PR TITLE
[#117522857] Install bash in the git-ssh container

### DIFF
--- a/git-ssh/Dockerfile
+++ b/git-ssh/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.3
 
-ENV PACKAGES "git openssh-client gnupg"
+ENV PACKAGES "git openssh-client gnupg bash"
 
 RUN apk add --update $PACKAGES && rm -rf /var/cache/apk/*
 

--- a/git-ssh/git-ssh_spec.rb
+++ b/git-ssh/git-ssh_spec.rb
@@ -29,6 +29,10 @@ describe "image" do
     expect(command('ssh -V').exit_status).to eq(0)
   end
 
+  it "can run bash" do
+    expect(command('bash --version').exit_status).to eq(0)
+  end
+
   it "/root/.ssh exists" do
     expect(file('/root/.ssh')).to be_directory
   end


### PR DESCRIPTION
What
----

We use fair complex scripts with this containers, on which we want
to set options like pipefail [1]. Alpine `sh` does support that option
but not the GNU sh, which causes the scripts fail if they are
executed or tested outside of this container (e.g. travis).

To solve this, we install bash in the container so that we can use
it in the scripts and make them portable.

How to test
---------

just run `rake build:git-ssh spec:git-ssh`. Travis should succed

Who?
---

Anyone but @keymon or @henrytk

[1] https://bclary.com/blog/2006/07/20/pipefail-testing-pipeline-exit-codes/