### PR TITLE
Re-enable cf cli version 6.16.1 again

### DIFF
--- a/cf-acceptance-tests/Dockerfile
+++ b/cf-acceptance-tests/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.6.0-wheezy
 
-RUN curl -L 'https://cli.run.pivotal.io/stable?release=linux64-binary&version=6.15.0' | tar -zx -C /usr/local/bin
+RUN curl -L 'https://cli.run.pivotal.io/stable?release=linux64-binary&version=6.16.1' | tar -zx -C /usr/local/bin
 RUN apt-get update \
       && apt-get install -y --no-install-recommends unzip \
       && rm -rf /var/lib/apt/lists/*

--- a/cf-acceptance-tests/cf-acceptance-tests_spec.rb
+++ b/cf-acceptance-tests/cf-acceptance-tests_spec.rb
@@ -3,7 +3,7 @@ require 'docker'
 require 'serverspec'
 
 GO_VERSION="1.6"
-CF_CLI_VERSION="6.15.0"
+CF_CLI_VERSION="6.16.1"
 
 describe "cf-acceptance-tests image" do
   before(:all) {

--- a/cf-cli/Dockerfile
+++ b/cf-cli/Dockerfile
@@ -5,5 +5,5 @@ ENV PACKAGES unzip curl ca-certificates git
 RUN apt-get update \
       && apt-get install -y --no-install-recommends $PACKAGES \
       && rm -rf /var/lib/apt/lists/*
-RUN curl -L 'https://cli.run.pivotal.io/stable?release=linux64-binary&version=6.15.0' | tar -zx -C /usr/local/bin
+RUN curl -L 'https://cli.run.pivotal.io/stable?release=linux64-binary&version=6.16.1' | tar -zx -C /usr/local/bin
 

--- a/cf-cli/cf-acceptance-tests_spec.rb
+++ b/cf-cli/cf-acceptance-tests_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'docker'
 require 'serverspec'
 
-CF_CLI_VERSION="6.15.0"
+CF_CLI_VERSION="6.16.1"
 
 describe "cf-cli image" do
   before(:all) {


### PR DESCRIPTION
# What

## DO NOT MERGE THIS UNTIL AFTER  https://github.com/alphagov/paas-cf/pull/207 HAS BEEN MERGED AND ALL ENVIRONMENTS HAVE BEEN UPDATED - The newer cf-cli client will cause acceptance-tests to fail on deployments which have not been upgraded to CF v233

Sometimes there is this amazing feeling of deja-vu.... This PR reverts the reversion of the earlier commit to use cf cli 6.16.1 16dc7b45179895dde86a8ac4bb466cf3d74495aa.

The cf-acceptance-tests include a check that the cf command line client meets the required version.
For CF v233 the required version for the cli is 6.16.1

This PR bumps the version numbers in the Dockerfile and spec file.

# How to test 

```
docker rmi cf-cli # Remove any existing image for cf-cli on your machine
docker build -t cf-cli .
docker run -i -t cf-cli cf --version
```
Repeat the above steps for the cf-acceptance-test container too as this PR updates both containers.


# Who can review this
Anyone on the team except for @saliceti, @HenryTK or myself.

