### PR TITLE
[#117705909] Add cf-uaac container

### DIFF
--- a/cf-uaac/Dockerfile
+++ b/cf-uaac/Dockerfile
@@ -1,0 +1,5 @@
+FROM ruby:2.2-alpine
+
+RUN apk add --update musl-dev gcc make g++ && rm -rf /var/cache/apk/*
+
+RUN gem install cf-uaac -v 3.2.0 --no-rdoc --no-ri

--- a/cf-uaac/README.md
+++ b/cf-uaac/README.md
@@ -1,0 +1,19 @@
+Container for running uaac cli.
+
+
+* `uaac` CLI
+
+Based on the [ruby:slim](https://hub.docker.com/_/ruby/) image.
+
+## Build locally
+
+```
+$ cd cf-uaac
+$ docker build -t cf-uaac .
+```
+
+## Run
+
+```
+docker run -i -t cf-uaac uaac --version
+```

--- a/cf-uaac/cf-uaac_spec.rb
+++ b/cf-uaac/cf-uaac_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+require 'docker'
+require 'serverspec'
+
+UAAC_VERSION="3.2.0"
+
+describe "cf-uaac image" do
+  before(:all) {
+    set :docker_image, find_image_id('cf-uaac:latest')
+  }
+
+  it "has the expected version of uaac" do
+    expect(
+      command("uaac --version").stdout.strip
+    ).to eq("UAA client #{UAAC_VERSION}")
+  end
+
+end


### PR DESCRIPTION
##What

In order to create temporary admin accounts for use in the acceptance-tests and smoke-test steps in our pipeline, we need to use the CF `uaac` command line client. This means that we're going to need a docker image with the `uaac` command available.

This container will use uaac version 3.2.0, which will work with our current CF v233 release.

## How to test

Build the container using `rake build:cf-uaac`
Check that it passes it's rspec tests using `rspec cf-uaac/cf-uaac_spec.rb` 
Get a shell running in the conainer using `docker run -i -t cf-uaac ash`
Run the `uaac` command and confirm that it returns it's help page.

## Who can review this PR

Not @mtekel or myself