### PR TITLE
We use Go 1.6 not 1.5

### DIFF
--- a/cf-acceptance-tests/README.md
+++ b/cf-acceptance-tests/README.md
@@ -3,7 +3,7 @@ Container for running CloudFoundry acceptance tests.
 It includes all the dependencies of the [CF test
 helpers](https://github.com/cloudfoundry-incubator/cf-test-helpers):
 
-* Go 1.5 compiler
+* Go compiler
 * `cf` CLI
 * `curl`
 * [`godep`](github.com/tools/godep)


### PR DESCRIPTION
# What
The README was wrong when it comes to Go complier version.

# How

Check it the version in Dockerfile and Readme are same.

# Who

Not me