### PR TITLE
[#117512371] Upgrade the cached bosh-aws-cpi to version 52

### DIFF
--- a/bosh-init/Dockerfile
+++ b/bosh-init/Dockerfile
@@ -13,8 +13,8 @@ RUN apt-get install -y wget
 RUN wget -q -O /usr/local/bin/bosh-init --no-check-certificate ${BOSH_INIT_URL}
 RUN chmod +x /usr/local/bin/bosh-init
 
-ENV BOSH_AWS_CPI_URL https://bosh.io/d/github.com/cloudfoundry-incubator/bosh-aws-cpi-release?v=44
-ENV BOSH_AWS_CPI_CHECKSUM a1fe03071e8b9bf1fa97a4022151081bf144c8bc
+ENV BOSH_AWS_CPI_URL https://bosh.io/d/github.com/cloudfoundry-incubator/bosh-aws-cpi-release?v=52
+ENV BOSH_AWS_CPI_CHECKSUM dc4a0cca3b33dce291e4fbeb9e9948b6a7be3324
 
 COPY bosh_init_cache /tmp/bosh_init_cache/
 RUN /tmp/bosh_init_cache/seed_bosh_init_cache.sh && \

--- a/bosh-init/bosh-init_spec.rb
+++ b/bosh-init/bosh-init_spec.rb
@@ -4,7 +4,6 @@ require 'serverspec'
 
 BOSH_INIT_PACKAGES = "build-essential zlibc zlib1g-dev ruby ruby-dev openssl libxslt1-dev libxml2-dev \
     libssl-dev libreadline6 libreadline6-dev libyaml-dev libsqlite3-dev sqlite3"
-BOSH_INIT_BIN = "/usr/local/bin/bosh-init"
 BOSH_INIT_VERSION = "0.0.80-a62aad7-2015-10-28T01:52:30Z"
 
 describe "bosh-init image" do
@@ -26,16 +25,10 @@ describe "bosh-init image" do
     end
   end
 
-  it "checks if bosh-init binary exists and is a file" do
-    expect(file(BOSH_INIT_BIN)).to be_file
-  end
-
-  it "checks if bosh-init binary is executable" do
-    expect(file(BOSH_INIT_BIN)).to be_mode 755
-  end
-
-  it "has the bosh-init version #{BOSH_INIT_VERSION}" do
-    expect(bosh_init_version).to eq("version #{BOSH_INIT_VERSION}")
+  it "installs the expected version of bosh-init" do
+    expect(
+      command("bosh-init --version").stdout.strip
+    ).to eq("version #{BOSH_INIT_VERSION}")
   end
 
   it "contains the compiled CPI packages" do
@@ -51,9 +44,5 @@ describe "bosh-init image" do
     expect(cpi_package).to be
 
     expect(file("#{installation_path}/packages/bosh_aws_cpi/bin/aws_cpi")).to be_executable
-  end
-
-  def bosh_init_version
-    command("bosh-init --version").stdout.strip
   end
 end

--- a/bosh-init/bosh_init_cache/seed_bosh_init_cache.sh
+++ b/bosh-init/bosh_init_cache/seed_bosh_init_cache.sh
@@ -9,10 +9,15 @@ cd "${WORKING_DIR}"
 
 sed "s|BOSH_AWS_CPI_URL|${BOSH_AWS_CPI_URL}|; s|BOSH_AWS_CPI_CHECKSUM|${BOSH_AWS_CPI_CHECKSUM}|" minimal_in.yml > minimal.yml
 
+RED='\033[0;31m'
+NO_COLOUR='\033[0m'
+
+echo "${RED}"
 echo "###############################################"
 echo "# Compiling AWS CPI release...                #"
 echo "# The deploy will error, but that's expected. #"
 echo "###############################################"
+echo "${NO_COLOUR}"
 
 set +e
 bosh-init deploy minimal.yml


### PR DESCRIPTION
# What

As part of the RDS broker story, we needed to upgrade the AWS CPI to get the change to allow security groups to be defined in a resource pool (https://github.com/cloudfoundry-incubator/bosh-aws-cpi-release/pull/28).

This PR therefore updates the cached CPI compilation to match the version used in the pipelines.

🚨  This should be merged along with https://github.com/alphagov/paas-cf/pull/260

# How to review

Code review.  Build container, and verify that tests pass.

# Who can review

Anyone but myself, @timmow or @jimconner 