### PR TITLE
[#117512371] Add ruby to cf-cli container.

### DIFF
--- a/cf-cli/Dockerfile
+++ b/cf-cli/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:wheezy
+FROM ruby:2.2-slim
 
 ENV PACKAGES unzip curl ca-certificates git
 

--- a/cf-cli/cf-acceptance-tests_spec.rb
+++ b/cf-cli/cf-acceptance-tests_spec.rb
@@ -32,4 +32,10 @@ describe "cf-cli image" do
       command("git --version").exit_status
     ).to eq(0)
   end
+
+  it "has ruby 2.2 available" do
+    cmd = command("ruby -v")
+    expect(cmd.exit_status).to eq(0)
+    expect(cmd.stdout).to match(/^ruby 2.2/)
+  end
 end


### PR DESCRIPTION
# What

This adds ruby to the cf-cli container so that we can script operations against the CF API more easily (eg
adding the security groups defined in the manifest).

# How to review

Verify that the tests pass. Verify that the cf-cli container does indeed have ruby available.

# Who can review

Anyone but myself.