### PR TITLE
[#118838943] Update bosh_cli gem to 1.3232.0

### DIFF
--- a/bosh-cli/Dockerfile
+++ b/bosh-cli/Dockerfile
@@ -1,5 +1,5 @@
 FROM ruby:2.2-alpine
 
-RUN gem install bosh_cli -v 1.3192.0 --no-rdoc --no-ri
+RUN gem install bosh_cli -v 1.3232.0 --no-rdoc --no-ri
 
 RUN apk add --update openssh-client file && rm -rf /var/cache/apk/*

--- a/bosh-cli/bosh-cli_spec.rb
+++ b/bosh-cli/bosh-cli_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'docker'
 require 'serverspec'
 
-BOSH_CLI_VERSION="1.3192.0"
+BOSH_CLI_VERSION="1.3232.0"
 
 describe "bosh-cli image" do
   before(:all) {


### PR DESCRIPTION
# What
bosh_cli gem version is now pinned in paas-cf. We want to use the same
version in the container as well.

# How to review
* Build and run local tests
* Run the bosh-cf pipeline with the new container by replacing `docker:///governmentpaas/bosh-cli` with `docker:///governmentpaas/bosh-cli#update_bosh_cli_gem`

# Who can review
Anyone but me