### PR TITLE
Bump AWS CLI version to 1.10.38

### DIFF
--- a/awscli/Dockerfile
+++ b/awscli/Dockerfile
@@ -1,11 +1,10 @@
 FROM governmentpaas/curl-ssl
 
-ENV AWSCLI_VERSION "1.9.21"
+ENV AWSCLI_VERSION "1.10.38"
 ENV PACKAGES "groff less python py-pip"
 
 RUN apk add --update $PACKAGES \
     && pip install awscli==$AWSCLI_VERSION \
     && apk --purge -v del py-pip \
     && rm -rf /var/cache/apk/*
-
 

--- a/awscli/awscli_spec.rb
+++ b/awscli/awscli_spec.rb
@@ -5,7 +5,7 @@ require 'serverspec'
 AWSCLI_PACKAGES = "curl openssl ca-certificates less"
 
 AWSCLI_BIN = "/usr/bin/aws"
-AWSCLI_VERSION = "1.9.21"
+AWSCLI_VERSION = "1.10.38"
 
 describe "awscli image" do
   before(:all) {


### PR DESCRIPTION
# What
In order to add aws sts `get-caller-identity` command which we need for
tagging RDS instances in upgrade master password story (#118841005).

# Testing
Run `rake build:awscli`. Then `rspec awscli`. You can check that the version inside container matches by hand and you can also check that it has `aws sts get-caller-identity` command.

# Who
not me