### PR TITLE
[#111700216] Upgrade spruce to 1.4.5

### DIFF
--- a/spruce/Dockerfile
+++ b/spruce/Dockerfile
@@ -1,12 +1,10 @@
-FROM golang:1.5.1-alpine
+FROM alpine:3.4
 
-ENV SPRUCE_VERSION 0.13.0
+ENV SPRUCE_VERSION 1.4.5
 
-RUN apk add --update git \
-  && go get -d github.com/geofffranks/spruce \
-  && cd ${GOPATH}/src/github.com/geofffranks/spruce \
-  && git checkout v${SPRUCE_VERSION} \
-  && export GOPATH=$(pwd)/Godeps/_workspace:$GOPATH \
-  && go install \
-  && apk del git \
+RUN apk add --update wget ca-certificates \
+  && wget https://github.com/geofffranks/spruce/releases/download/v${SPRUCE_VERSION}/spruce-linux-amd64 \
+  && chmod +x spruce-linux-amd64 \
+  && mv spruce-linux-amd64 /usr/local/bin/spruce \
+  && apk del wget ca-certificates \
   && rm -rf /var/cache/apk/*

--- a/spruce/spruce_spec.rb
+++ b/spruce/spruce_spec.rb
@@ -2,8 +2,9 @@ require 'spec_helper'
 require 'docker'
 require 'serverspec'
 
-SPRUCE_BIN = "/go/bin/spruce"
-SPRUCE_VERSION = "0.13.0"
+SPRUCE_BIN = "/usr/local/bin/spruce"
+SPRUCE_VERSION = "1.4.5"
+ALPINE_VERSION = "3.4"
 
 describe "spruce image" do
   before(:all) {
@@ -11,7 +12,7 @@ describe "spruce image" do
   }
 
   it "installs the right version of Alpine Linux" do
-    expect(os_version).to include("Alpine Linux 3.2")
+    expect(os_version).to include("Alpine Linux #{ALPINE_VERSION}")
   end
 
   def os_version


### PR DESCRIPTION
### What
Spruce now provides static builds, which enables us to run it from
Alpine (see https://github.com/geofffranks/spruce/issues/128).

Use new spruce binary to reduce container size by 80%:
 * old 73MB
 * new 14MB

### Testing
Render manifests using old spruce. Render manifest using new spruce. Compare - there should be no differences. You could also upgrade your local spruce to 1.4.5 & run manifest rendering tests (or all tests - `make test`)

### Who
not @mtekel