### PR TITLE
[#122183539] Add json-minify container

### DIFF
--- a/bosh-cli/bosh-cli_spec.rb
+++ b/bosh-cli/bosh-cli_spec.rb
@@ -31,7 +31,8 @@ describe "bosh-cli image" do
     # See https://github.com/nahi/httpclient/blob/v2.7.1/lib/httpclient/ssl_config.rb#L441-L452
     # (httpclient is a dependency of bosh_cli)
     # With an older version of openssl, bosh_cli spits out warnings.
-    cmd = command("openssl version")
+    cmd = command("ruby -ropenssl -e 'puts OpenSSL::OPENSSL_VERSION'")
+
     expect(cmd.exit_status).to eq(0)
 
     ssl_version_str = cmd.stdout.strip

--- a/json-minify/Dockerfile
+++ b/json-minify/Dockerfile
@@ -1,0 +1,3 @@
+FROM ruby:2.3-alpine
+
+RUN gem install json-minify -v 0.0.2 --no-document

--- a/json-minify/README.md
+++ b/json-minify/README.md
@@ -1,0 +1,17 @@
+Container for Ruby implemenation of json-minify.
+
+
+Based on the [ruby:alpine](https://hub.docker.com/r/library/ruby/tags/) image.
+
+## Build locally
+
+```
+$ cd json-minify
+$ docker build -t json-minify .
+```
+
+## Run
+
+```
+docker run json-minify gem list
+```

--- a/json-minify/json-minify_spec.rb
+++ b/json-minify/json-minify_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+require 'docker'
+require 'serverspec'
+
+JSON_MINIFY_VERSION="0.0.2"
+
+describe "json-minify image" do
+  before(:all) {
+    set :docker_image, find_image_id('json-minify:latest')
+  }
+
+  it "has the expected version of the json-minify gem" do
+    expect(
+      command("gem list").stdout.strip
+    ).to include("json-minify (0.0.2)")
+  end
+
+end


### PR DESCRIPTION
# What

[#122183539 - Visibility of important platform metrics](https://www.pivotaltracker.com/story/show/122183539)

We require use of the json-minify Ruby Gem to insert JSON as values in our CloudFoundry manifest. Each of these lines represents the configuration of a Grafana dashboard. This image allows us to isolate this dependency and not have to run bundler in the pipeline.

# How to review

* Check out the `122183539_json_minify` branch
* Run the following to verify the `json-minify` Gem is installed:

```
cd json-minify
docker build -t json-minify .
docker run json-minify gem list
```

* Run `rspec json-minify/` to ensure the test passes.

# Who

Anyone but @saliceti or me