### PR TITLE
[#122183539] Fix wget in bosh-cli container for https sites.

### DIFF
--- a/bosh-cli/Dockerfile
+++ b/bosh-cli/Dockerfile
@@ -2,4 +2,4 @@ FROM ruby:2.2-alpine
 
 RUN gem install bosh_cli -v 1.3232.0 --no-rdoc --no-ri
 
-RUN apk add --update openssh-client file && rm -rf /var/cache/apk/*
+RUN apk add --update openssl openssh-client file && rm -rf /var/cache/apk/*

--- a/bosh-cli/bosh-cli_spec.rb
+++ b/bosh-cli/bosh-cli_spec.rb
@@ -28,11 +28,12 @@ describe "bosh-cli image" do
   end
 
   it "has a new enough version of openssl available" do
+    # wget (from busybox) requires openssl to be able to connect to https sites.
+
     # See https://github.com/nahi/httpclient/blob/v2.7.1/lib/httpclient/ssl_config.rb#L441-L452
     # (httpclient is a dependency of bosh_cli)
     # With an older version of openssl, bosh_cli spits out warnings.
-    cmd = command("ruby -ropenssl -e 'puts OpenSSL::OPENSSL_VERSION'")
-
+    cmd = command("openssl version")
     expect(cmd.exit_status).to eq(0)
 
     ssl_version_str = cmd.stdout.strip


### PR DESCRIPTION
# What

The current version of the ruby:2.2-alpine no longer includes the
openssl CLI. That means that the busybox provided wget command can no
longer connect to https sites, and instead gives the following error:

```
wget: can't execute 'ssl_helper': No such file or directory
wget: error getting response: Connection reset by peer
```

This adds openssl to this container to fix this issue.

This is a partial revert of cfc7785e, which updated the tests to check for
the libssl version instead because we didn't think that the openssl CLI
was needed.

## How to review

Verify that the tests pass in Travis.

Verify that wget works with https sites:

```sh
cd bosh-cli
docker rmi ruby:2.2-alpine # To ensure we get the latest.
docker build -t bosh-cli .
docker run bosh-cli wget https://www.google.com
```

## Who can review

Anyone but myself.