### PR TITLE
[#117991263] Upgrade bosh-init to 0.0.95

### DIFF
--- a/bosh-init/Dockerfile
+++ b/bosh-init/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:14.04
 
-ENV BOSH_INIT_VERSION 0.0.80
+ENV BOSH_INIT_VERSION 0.0.95
 ENV BOSH_INIT_URL https://s3.amazonaws.com/bosh-init-artifacts/bosh-init-${BOSH_INIT_VERSION}-linux-amd64
 ENV BOSH_INIT_PACKAGES "build-essential zlibc zlib1g-dev ruby ruby-dev openssl libxslt1-dev libxml2-dev \
     libssl-dev libreadline6 libreadline6-dev libyaml-dev libsqlite3-dev sqlite3"

--- a/bosh-init/bosh-init_spec.rb
+++ b/bosh-init/bosh-init_spec.rb
@@ -4,7 +4,7 @@ require 'serverspec'
 
 BOSH_INIT_PACKAGES = "build-essential zlibc zlib1g-dev ruby ruby-dev openssl libxslt1-dev libxml2-dev \
     libssl-dev libreadline6 libreadline6-dev libyaml-dev libsqlite3-dev sqlite3"
-BOSH_INIT_VERSION = "0.0.80-a62aad7-2015-10-28T01:52:30Z"
+BOSH_INIT_VERSION = "0.0.95-365cb4e-2016-06-29T23:30:18Z"
 
 describe "bosh-init image" do
   before(:all) {


### PR DESCRIPTION
### What

Upgrade bosh-init version. This is required to deploy new concourse version, which uses various
"BOSH 2.0" features that are not supported in our previous bosh-init version.

### Testing
As a part of https://github.com/alphagov/paas-cf/pull/381

### Who
not @mtekel or @combor 