### PR TITLE
[#126965751] Add jq 1.5 to the cf-cli container

### DIFF
--- a/cf-cli/Dockerfile
+++ b/cf-cli/Dockerfile
@@ -6,4 +6,4 @@ RUN apt-get update \
       && apt-get install -y --no-install-recommends $PACKAGES \
       && rm -rf /var/lib/apt/lists/*
 RUN curl -L 'https://cli.run.pivotal.io/stable?release=linux64-binary&version=6.16.1' | tar -zx -C /usr/local/bin
-
+RUN curl -L 'https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64' -o /usr/local/bin/jq && chmod +x /usr/local/bin/jq

--- a/cf-cli/cf-acceptance-tests_spec.rb
+++ b/cf-cli/cf-acceptance-tests_spec.rb
@@ -33,6 +33,12 @@ describe "cf-cli image" do
     ).to eq(0)
   end
 
+  it "has jq available" do
+    cmd = command("jq --version")
+    expect(cmd.exit_status).to eq(0)
+    expect(cmd.stdout).to match(/^jq-1.5/)
+  end
+
   it "has ruby 2.2 available" do
     cmd = command("ruby -v")
     expect(cmd.exit_status).to eq(0)


### PR DESCRIPTION
[#126965751 Test users not removed from CC DB](https://www.pivotaltracker.com/story/show/126965751)

What
====

We need to parse the output of `cf curl /v2/users` to list all the existing users created by the acceptance tests. For this jq is perfect.

We consider that this really useful and it will be used in other stories in the future, so we add it as a basic tool in the cf-cli container.

We want to use the regex based functions, so jq must be >= 1.5 and must be compiled with ONIGURUMA regex library. The Ubuntu package is 1.4, so we will pull the static binary released upstream.

Dependencies
-----------------

Please merge #65 first and rebase.

This could be reviewed together with https://github.com/alphagov/paas-docker-cloudfoundry-tools/pull/62


How to test?
-----------

Travis shall pass.

You can test locally with `rake build:cf-cli spec:cf-cli`.

Then you can test: `docker run -ti cf-cli jq --version`

Who?
----

Anyone but @richardc or @keymon