### PR TITLE
[#126965751] Use Alpine for cf-cli container base image

### DIFF
--- a/cf-cli/Dockerfile
+++ b/cf-cli/Dockerfile
@@ -1,9 +1,8 @@
-FROM ruby:2.2-slim
+FROM alpine:3.3
 
-ENV PACKAGES unzip curl ca-certificates git
+ENV PACKAGES "unzip curl openssl ca-certificates git ruby"
 
-RUN apt-get update \
-      && apt-get install -y --no-install-recommends $PACKAGES \
-      && rm -rf /var/lib/apt/lists/*
+RUN apk add --update $PACKAGES && rm -rf /var/cache/apk/*
+
 RUN curl -L 'https://cli.run.pivotal.io/stable?release=linux64-binary&version=6.21.1' | tar -zx -C /usr/local/bin
 RUN curl -L 'https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64' -o /usr/local/bin/jq && chmod +x /usr/local/bin/jq

--- a/cf-cli/Dockerfile
+++ b/cf-cli/Dockerfile
@@ -5,5 +5,5 @@ ENV PACKAGES unzip curl ca-certificates git
 RUN apt-get update \
       && apt-get install -y --no-install-recommends $PACKAGES \
       && rm -rf /var/lib/apt/lists/*
-RUN curl -L 'https://cli.run.pivotal.io/stable?release=linux64-binary&version=6.16.1' | tar -zx -C /usr/local/bin
+RUN curl -L 'https://cli.run.pivotal.io/stable?release=linux64-binary&version=6.21.1' | tar -zx -C /usr/local/bin
 RUN curl -L 'https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64' -o /usr/local/bin/jq && chmod +x /usr/local/bin/jq

--- a/cf-cli/cf-acceptance-tests_spec.rb
+++ b/cf-cli/cf-acceptance-tests_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'docker'
 require 'serverspec'
 
-CF_CLI_VERSION="6.16.1"
+CF_CLI_VERSION="6.21.1"
 
 describe "cf-cli image" do
   before(:all) {


### PR DESCRIPTION
[#126965751 Test users not removed from CC DB.](https://www.pivotaltracker.com/story/show/126965751)

What
====

We use alpine base image whenever is possible to speed up the pipelines.   But in the case of cf-cli we were using Ubuntu because [the cf-cli was not compiled statically](https://github.com/cloudfoundry/cli/issues/807). Since 6.17.1. they build it statically, so we can move the container to alpine.

Dependencies
------------

Please merge #65, and #61 first and rebase

How to test
-----------

Travis shall pass.

You can test locally with `rake build:cf-cli spec:cf-cli`.

Then you can test: `docker run -ti cf-cli jq --version`

Who?
----

Anyone but @richardc or @keymon