### PR TITLE
[#126965751] Pin ruby to 2.2 for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
+language: ruby
+rvm:
+  - 2.2
+
 sudo: required
 
 services:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -51,6 +51,3 @@ DEPENDENCIES
   rake (~> 10.4.2)
   serverspec (~> 2.19)
   should_not (~> 1.1)
-
-BUNDLED WITH
-   1.10.6


### PR DESCRIPTION
[#126965751 Test users not removed from CC DB.](https://www.pivotaltracker.com/story/show/126965751)

What
====

Pin ruby version in travis to ruby 2.2

We are having issues building json gemfile in travis:

Installing json 1.8.1 with native extensions:

    Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

    current directory: /home/travis/build/alphagov/paas-docker-cloudfoundry-tools/vendor/bundle/ruby/2.3.0/gems/json-1.8.1/ext/json/ext/generator

    /home/travis/.rvm/rubies/ruby-2.3.1/bin/ruby -r ./siteconf20160817-3324-1osslyn.rb extconf.rb

    creating Makefile

    current directory: /home/travis/build/alphagov/paas-docker-cloudfoundry-tools/vendor/bundle/ruby/2.3.0/gems/json-1.8.1/ext/json/ext/generator

    make "DESTDIR=" clean

    current directory: /home/travis/build/alphagov/paas-docker-cloudfoundry-tools/vendor/bundle/ruby/2.3.0/gems/json-1.8.1/ext/json/ext/generator

    make "DESTDIR="

    compiling generator.c

    In file included from generator.c:1:0:

    ../fbuffer/fbuffer.h: In function ‘fbuffer_to_s’:

    ../fbuffer/fbuffer.h:175:47: error: macro "rb_str_new" requires 2 arguments, but only 1 given

    VALUE result = rb_str_new(FBUFFER_PAIR(fb));

                                            ^

    ../fbuffer/fbuffer.h:175:20: warning: initialization makes integer from pointer without a cast [enabled by default]

    VALUE result = rb_str_new(FBUFFER_PAIR(fb));

                    ^

    make: *** [generator.o] Error 1

    make failed, exit code 2

In previous executions ([1] vs [2]), with ruby 2.2 it was working fine.

We decided pin the ruby version for the time being.

[1] https://travis-ci.org/alphagov/paas-docker-cloudfoundry-tools/builds/147760906#L165
[2] https://travis-ci.org/alphagov/paas-docker-cloudfoundry-tools/builds/152935537#L301

How to test?
----------

Travis should pass

Who?
---

Anyone but @keymon or @richardc


https://github.com/alphagov/paas-docker-cloudfoundry-tools