### PR TITLE
[#126965751 Upgrade json gem to ~> 2.0.0]

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,5 +11,5 @@ gem 'should_not', '~> 1.1'
 
 gem 'rake', '~> 10.4.2'
 
-# The default latest json 1.8.3 fails on some macs
-gem 'json', '= 1.8.1'
+# The json 1.8.3 fails on some macs and 1.8.1 fails in travis
+gem 'json', '~> 2.0.0'

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@
 
 source 'https://rubygems.org'
 
-gem 'docker-api', '~> 1.21'
+gem 'docker-api', '~> 1.31'
 gem 'serverspec', '~> 2.19'
 
 # You should_not start your specs with the string "should"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,7 +6,7 @@ GEM
       excon (>= 0.38.0)
       json
     excon (0.45.4)
-    json (1.8.1)
+    json (2.0.2)
     multi_json (1.11.2)
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
@@ -47,7 +47,7 @@ PLATFORMS
 
 DEPENDENCIES
   docker-api (~> 1.21)
-  json (= 1.8.1)
+  json (~> 2.0.0)
   rake (~> 10.4.2)
   serverspec (~> 2.19)
   should_not (~> 1.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -51,6 +51,3 @@ DEPENDENCIES
   rake (~> 10.4.2)
   serverspec (~> 2.19)
   should_not (~> 1.1)
-
-BUNDLED WITH
-   1.10.6

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,43 +2,43 @@ GEM
   remote: https://rubygems.org/
   specs:
     diff-lcs (1.2.5)
-    docker-api (1.23.0)
+    docker-api (1.31.0)
       excon (>= 0.38.0)
       json
-    excon (0.45.4)
+    excon (0.51.0)
     json (2.0.2)
-    multi_json (1.11.2)
+    multi_json (1.12.1)
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
-    net-ssh (2.9.2)
+    net-ssh (3.2.0)
     net-telnet (0.1.1)
     rake (10.4.2)
-    rspec (3.4.0)
-      rspec-core (~> 3.4.0)
-      rspec-expectations (~> 3.4.0)
-      rspec-mocks (~> 3.4.0)
-    rspec-core (3.4.1)
-      rspec-support (~> 3.4.0)
-    rspec-expectations (3.4.0)
+    rspec (3.5.0)
+      rspec-core (~> 3.5.0)
+      rspec-expectations (~> 3.5.0)
+      rspec-mocks (~> 3.5.0)
+    rspec-core (3.5.2)
+      rspec-support (~> 3.5.0)
+    rspec-expectations (3.5.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.4.0)
+      rspec-support (~> 3.5.0)
     rspec-its (1.2.0)
       rspec-core (>= 3.0.0)
       rspec-expectations (>= 3.0.0)
-    rspec-mocks (3.4.0)
+    rspec-mocks (3.5.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.4.0)
-    rspec-support (3.4.1)
-    serverspec (2.24.3)
+      rspec-support (~> 3.5.0)
+    rspec-support (3.5.0)
+    serverspec (2.36.0)
       multi_json
       rspec (~> 3.0)
       rspec-its
-      specinfra (~> 2.43)
+      specinfra (~> 2.53)
     sfl (2.2)
     should_not (1.1.0)
-    specinfra (2.44.3)
+    specinfra (2.61.1)
       net-scp
-      net-ssh (~> 2.7)
+      net-ssh (>= 2.7, < 4.0)
       net-telnet
       sfl
 
@@ -46,7 +46,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  docker-api (~> 1.21)
+  docker-api (~> 1.31)
   json (~> 2.0.0)
   rake (~> 10.4.2)
   serverspec (~> 2.19)


### PR DESCRIPTION
[#126965751 Test users not removed from CC DB.](https://www.pivotaltracker.com/story/show/126965751)

What
====

Upgrade json gem to ~> 2.0.0

Previously the latest json gem 1.8.3 was not compiling on MacOSX
and it was pin to 1.8.1.

But now We are having issues building json 1.8.1 gemfile in travis:

    Installing json 1.8.1 with native extensions

    Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

    current directory: /home/travis/build/alphagov/paas-docker-cloudfoundry-tools/vendor/bundle/ruby/2.3.0/gems/json-1.8.1/ext/json/ext/generator

    /home/travis/.rvm/rubies/ruby-2.3.1/bin/ruby -r ./siteconf20160817-3324-1osslyn.rb extconf.rb

    creating Makefile

    current directory: /home/travis/build/alphagov/paas-docker-cloudfoundry-tools/vendor/bundle/ruby/2.3.0/gems/json-1.8.1/ext/json/ext/generator

    make "DESTDIR=" clean

    current directory: /home/travis/build/alphagov/paas-docker-cloudfoundry-tools/vendor/bundle/ruby/2.3.0/gems/json-1.8.1/ext/json/ext/generator

    make "DESTDIR="

    compiling generator.c

    In file included from generator.c:1:0:

    ../fbuffer/fbuffer.h: In function ‘fbuffer_to_s’:

    ../fbuffer/fbuffer.h:175:47: error: macro "rb_str_new" requires 2 arguments, but only 1 given

    VALUE result = rb_str_new(FBUFFER_PAIR(fb));

                                            ^

    ../fbuffer/fbuffer.h:175:20: warning: initialization makes integer from pointer without a cast [enabled by default]

    VALUE result = rb_str_new(FBUFFER_PAIR(fb));

                    ^

    make: *** [generator.o] Error 1

    make failed, exit code 2

In previous executions ([1] vs [2]), with ruby 2.2 it was working fine.

We decided to upgrade

[1] https://travis-ci.org/alphagov/paas-docker-cloudfoundry-tools/builds/147760906#L165
[2] https://travis-ci.org/alphagov/paas-docker-cloudfoundry-tools/builds/152935537#L301

How to test?
----------

Travis should pass

Who?
---

Anyone but @keymon or @richardc