### PR TITLE
[#126965751]  Upgrade to docker-api 1.31 gem and pin ruby to 2.2 to support travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
+language: ruby
+rvm:
+  - 2.2
+
 sudo: required
 
 services:

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@
 
 source 'https://rubygems.org'
 
-gem 'docker-api', '~> 1.21'
+gem 'docker-api', '~> 1.31'
 gem 'serverspec', '~> 2.19'
 
 # You should_not start your specs with the string "should"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -51,6 +51,3 @@ DEPENDENCIES
   rake (~> 10.4.2)
   serverspec (~> 2.19)
   should_not (~> 1.1)
-
-BUNDLED WITH
-   1.10.6

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,10 +2,10 @@ GEM
   remote: https://rubygems.org/
   specs:
     diff-lcs (1.2.5)
-    docker-api (1.23.0)
+    docker-api (1.31.0)
       excon (>= 0.38.0)
       json
-    excon (0.45.4)
+    excon (0.51.0)
     json (1.8.1)
     multi_json (1.11.2)
     net-scp (1.2.1)
@@ -46,7 +46,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  docker-api (~> 1.21)
+  docker-api (~> 1.31)
   json (= 1.8.1)
   rake (~> 10.4.2)
   serverspec (~> 2.19)


### PR DESCRIPTION
[#126965751 Test users not removed from CC DB.](https://www.pivotaltracker.com/story/show/126965751)

What
====

Pin ruby version in travis to ruby 2.2, as  we are having issues building json gem in travis ([here](https://travis-ci.org/alphagov/paas-docker-cloudfoundry-tools/builds/147760906#L165) vs [here](https://travis-ci.org/alphagov/paas-docker-cloudfoundry-tools/builds/152935537#L301)) and we decided to use ruby 2.2 as the standard in the team.

Additionally Travis docker service has been upgraded and we need to upgrade the clients. Otherwise, the builds fail [with this error](https://travis-ci.org/alphagov/paas-docker-cloudfoundry-tools/builds/153019275#L1860):
``` 
Failure/Error: image = Docker::Image.all().detect{ |i| i.info['RepoTags'].include? name }
Docker::Error::ClientError:
400 Bad Request: malformed Host header
```

How to test
-----------

Travis shall pass.

Who?
----

Anyone but @richardc or @keymon