### PR TITLE
 [#126965751] Unpin the postgresql client version

### DIFF
--- a/psql/Dockerfile
+++ b/psql/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:3.3
 
-ENV PACKAGES "postgresql-client=9.4.6-r0"
+ENV PACKAGES "postgresql-client"
 
 RUN apk add --update $PACKAGES && rm -rf /var/cache/apk/*

--- a/psql/psql_spec.rb
+++ b/psql/psql_spec.rb
@@ -3,8 +3,6 @@ require 'docker'
 require 'serverspec'
 
 PSQL_PACKAGE = 'postgresql-client'
-PSQL_VERSION = '9.4.6'
-PSQL_PACKAGE_VERSION = PSQL_VERSION + '-r0'
 
 describe "psql image" do
   before(:all) {
@@ -21,15 +19,11 @@ describe "psql image" do
 
   it "installs required package" do
     expect(command("apk info #{PSQL_PACKAGE}").stdout.strip).to \
-      include("#{PSQL_PACKAGE}-#{PSQL_PACKAGE_VERSION}")
+      include("#{PSQL_PACKAGE}")
   end
 
   it "can run psql" do
     expect(command('psql --version').exit_status).to eq(0)
-  end
-
-  it "has the right version" do
-    expect(command("psql --version").stdout.strip).to include(PSQL_VERSION)
   end
 
 end


### PR DESCRIPTION
Alpine remove old versions of the postgres client from their `main` apt
index when upgrading, meaning this will frequently break. The postgres
client libraries are backward compatible so there's no need to pin.