### PR TITLE
[#126965751] Install ruby gem json in cf-cli container

### DIFF
--- a/cf-cli/Dockerfile
+++ b/cf-cli/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.3
 
-ENV PACKAGES "unzip curl openssl ca-certificates git ruby"
+ENV PACKAGES "unzip curl openssl ca-certificates git ruby ruby-json"
 
 RUN apk add --update $PACKAGES && rm -rf /var/cache/apk/*
 

--- a/cf-cli/cf-acceptance-tests_spec.rb
+++ b/cf-cli/cf-acceptance-tests_spec.rb
@@ -44,4 +44,9 @@ describe "cf-cli image" do
     expect(cmd.exit_status).to eq(0)
     expect(cmd.stdout).to match(/^ruby 2.2/)
   end
+
+  it "has ruby json gem available" do
+    cmd = command("ruby -e 'require \"json\"'")
+    expect(cmd.exit_status).to eq(0)
+  end
 end


### PR DESCRIPTION
[#126965751 Test users not removed from CC DB.](https://www.pivotaltracker.com/story/show/126965751)

What
====


After merging #62, our pipeline fail when executing a ruby script which required json.                                                            
                                                                                
Although json is one of the basic packages shipped with ruby[1], Alpine extracts it in a different package ruby-json. We need to explicitely add that dependency.                                                
                                                                                
We avoid running `bundle install` in the pipeline to avoid increase the time to run. We normally try to keep the scripts simple and without dependencies, but `json` is a really basic library.                 
                                                                                
[1] https://zzz.buzz/2016/02/29/default-gems-bundled-with-ruby/                 
[2] http://git.alpinelinux.org/cgit/aports/tree/main/ruby/APKBUILD?h=3.4-stable&id=cbdb9b2e42bbd7a67f0945bf7bcb8e79ddcae742#n190
                                                                                


How to test
-----------

Travis shall pass.

You can test locally with `rake build:cf-cli spec:cf-cli`.

Who?
---

Anyone but @keymon