### PR TITLE
[#130003999] Remove container size info from terraform README.

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -12,13 +12,3 @@ This container allows you to run Terraform inside a Docker container.
 ```
 docker run -ti terraform terraform
 ```
-
-## Container size and binary whitelist
-
-The Terraform installation is quite large; 30~ provider and provisioner
-binaries at 10~20M each. In order to reduce the size of the final container
-we only install the providers and provisioners that we expect to use. A list
-of these is maintained in the [Dockerfile](Dockerfile). We don't expect to
-need to do this in the future if [hashicorp/terraform#4233][] is solved.
-
-[hashicorp/terraform#4233]: https://github.com/hashicorp/terraform/issues/4233


### PR DESCRIPTION
## What

This no longer applies since we've upgraded to 0.7 (in fa630ad) as
terraform now has a single binary that includes all the built-in
providers.

## How to review

Review update README and confirm it makes sense to remove these details.

## Who can review

Anyone but myself.