### PR TITLE
[#127970229] Add Ginkgo to cf-acceptance-tests image

### DIFF
--- a/cf-acceptance-tests/Dockerfile
+++ b/cf-acceptance-tests/Dockerfile
@@ -6,3 +6,4 @@ RUN apt-get update \
       && rm -rf /var/lib/apt/lists/*
 
 RUN go get github.com/tools/godep
+RUN go get github.com/onsi/ginkgo/ginkgo

--- a/cf-acceptance-tests/cf-acceptance-tests_spec.rb
+++ b/cf-acceptance-tests/cf-acceptance-tests_spec.rb
@@ -23,6 +23,13 @@ describe "cf-acceptance-tests image" do
 
   end
 
+  it "has Ginkgo available" do
+    expect(
+      command("ginkgo version").exit_status
+    ).to eq(0)
+
+  end
+
   it "has the expected version of the CF CLI" do
     expect(
       command("cf --version").stdout


### PR DESCRIPTION
# What

Adding the Ginkgo binary will allow us to parallelise our custom acceptance tests. This will make testing the RDS broker much quicker, as the tests will now create several database instances as part of the changes in story #127970229[1]

[1] https://www.pivotaltracker.com/story/show/127970229

# How to review

* Pull this branch and `cd` into the `cf-acceptance-tests` directory. Run `rake build:cf-acceptance-tests && rake spec:cf-acceptance-tests`
* Change every pipeline task that uses the image to pin this version (add `image_resource.source.tag: 127970229_final_snapshot`) and run the pipeline.
* or as a part of https://github.com/alphagov/paas-cf/pull/508 which has a TMP commit to do the above
# Who

Anyone but me or @mtekel 