### PR TITLE
[#132060265] Add git to bosh-cli image

### DIFF
--- a/bosh-cli/Dockerfile
+++ b/bosh-cli/Dockerfile
@@ -2,4 +2,4 @@ FROM ruby:2.2-alpine
 
 RUN gem install bosh_cli -v 1.3232.0 --no-rdoc --no-ri
 
-RUN apk add --update openssl openssh-client file && rm -rf /var/cache/apk/*
+RUN apk add --update openssl openssh-client file git && rm -rf /var/cache/apk/*

--- a/bosh-cli/bosh-cli_spec.rb
+++ b/bosh-cli/bosh-cli_spec.rb
@@ -27,6 +27,10 @@ describe "bosh-cli image" do
     ).to eq(0)
   end
 
+  it "can run git" do
+    expect(command('git --version').exit_status).to eq(0)
+  end
+
   it "has a new enough version of openssl available" do
     # wget (from busybox) requires openssl to be able to connect to https sites.
 


### PR DESCRIPTION
[#132060265 Support: Wrong version of aws-broker deployed in CI](https://www.pivotaltracker.com/story/show/132060265)

What?
-----

We want to add a check to verify that the tag of the cloned version of  a bosh release matches with the intended version to upload before uploading it.

For that, we need git in this image to check tags or gather any git information from the git repositories of the bosh releases that we build.

How to review?
--------------

Travis should pass. You can run `rake build:bosh-cli spec:bosh-cli`

You can review it with the corresponding PR in paas-cf.


Who?
----

Anyone but @keymon