### PR TITLE
[#132651425] Upgrade cf-cli in cf-acceptance-tests to 6.21.1

### DIFF
--- a/cf-acceptance-tests/Dockerfile
+++ b/cf-acceptance-tests/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.6.0-wheezy
 
-RUN curl -L 'https://cli.run.pivotal.io/stable?release=linux64-binary&version=6.16.1' | tar -zx -C /usr/local/bin
+RUN curl -L 'https://cli.run.pivotal.io/stable?release=linux64-binary&version=6.21.1' | tar -zx -C /usr/local/bin
 RUN apt-get update \
       && apt-get install -y --no-install-recommends unzip \
       && rm -rf /var/lib/apt/lists/*

--- a/cf-acceptance-tests/cf-acceptance-tests_spec.rb
+++ b/cf-acceptance-tests/cf-acceptance-tests_spec.rb
@@ -3,7 +3,7 @@ require 'docker'
 require 'serverspec'
 
 GO_VERSION="1.6"
-CF_CLI_VERSION="6.16.1"
+CF_CLI_VERSION="6.21.1"
 
 describe "cf-acceptance-tests image" do
   before(:all) {


### PR DESCRIPTION
## What

CF 245 requires a newer CLI version than the one in this container (6.16.1). This PR therefore upgrades this to 6.21.1, which is also the version that the `cf-cli` container is already using (it was upgraded in a2d25c4).

## How to review

To test locally:

`bundle exec rake build:cf-acceptance-tests spec:cf-acceptance-tests`

`docker run --rm cf-acceptance-tests cf -v` should return version 6.21.1

## Who can review

Anyone but @keymon or myself.