### PR TITLE
[#132681767] Upgrade the cached bosh-aws-cpi to version 60

### DIFF
--- a/bosh-init/Dockerfile
+++ b/bosh-init/Dockerfile
@@ -13,8 +13,8 @@ RUN apt-get install -y wget
 RUN wget -q -O /usr/local/bin/bosh-init --no-check-certificate ${BOSH_INIT_URL}
 RUN chmod +x /usr/local/bin/bosh-init
 
-ENV BOSH_AWS_CPI_URL https://bosh.io/d/github.com/cloudfoundry-incubator/bosh-aws-cpi-release?v=52
-ENV BOSH_AWS_CPI_CHECKSUM dc4a0cca3b33dce291e4fbeb9e9948b6a7be3324
+ENV BOSH_AWS_CPI_URL https://bosh.io/d/github.com/cloudfoundry-incubator/bosh-aws-cpi-release?v=60
+ENV BOSH_AWS_CPI_CHECKSUM 8e40a9ff892204007889037f094a1b0d23777058
 
 COPY bosh_init_cache /tmp/bosh_init_cache/
 RUN /tmp/bosh_init_cache/seed_bosh_init_cache.sh && \


### PR DESCRIPTION
[#132681767 Upgrade BOSH #2: stemcell, CPI and new features](https://www.pivotaltracker.com/story/show/132681767)

What
----

We upgraded the CPI in bosh in PR https://github.com/alphagov/paas-cf/pull/570

We upgrade the cached CPI in the bosh-init to bring it inline with the version used in our pipelines.

Dependencies
------------

This should be merged together with PR https://github.com/alphagov/paas-cf/pull/570

How to test?
-----------

Travis tests this, should pass.

Otherwise: `rake build:bosh-cli spec:bosh-cli`

Who?
----

Anyone but @keymon