### PR TITLE
[#133751193] Upgrade terraform container to 0.7.10

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@
 
 source 'https://rubygems.org'
 
-gem 'docker-api', '~> 1.31'
+gem 'docker-api', '~> 1.32'
 gem 'serverspec', '~> 2.19'
 
 # You should_not start your specs with the string "should"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,10 +2,10 @@ GEM
   remote: https://rubygems.org/
   specs:
     diff-lcs (1.2.5)
-    docker-api (1.31.0)
+    docker-api (1.32.1)
       excon (>= 0.38.0)
       json
-    excon (0.51.0)
+    excon (0.54.0)
     json (1.8.1)
     multi_json (1.11.2)
     net-scp (1.2.1)
@@ -46,7 +46,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  docker-api (~> 1.31)
+  docker-api (~> 1.32)
   json (= 1.8.1)
   rake (~> 10.4.2)
   serverspec (~> 2.19)

--- a/terraform/Dockerfile
+++ b/terraform/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.3
+FROM alpine:3.4
 
 ENV PATH $PATH:/usr/local/bin
 ENV TERRAFORM_VER 0.7.10

--- a/terraform/Dockerfile
+++ b/terraform/Dockerfile
@@ -1,16 +1,13 @@
-FROM golang:1.7.1-alpine
+FROM alpine:3.3
 
 ENV PATH $PATH:/usr/local/bin
-ENV TERRAFORM_TAG datadog_dashboard_type_style
+ENV TERRAFORM_VER 0.7.10
+ENV TERRAFORM_SUM a6da76d6228349855f7c503b769fb231e6b1009add5e5b2586ecb7624e9ecf15
+ENV TERRAFORM_ZIP terraform_${TERRAFORM_VER}_linux_amd64.zip
 
-RUN apk add --update openssl openssh-client ca-certificates make bash git && rm -rf /var/cache/apk/*
+RUN apk add --update openssl openssh-client ca-certificates && rm -rf /var/cache/apk/*
 RUN set -ex \
-    && mkdir -p /go/src/github.com/hashicorp/ \
-    && cd /go/src/github.com/hashicorp/ \
-    && git clone https://github.com/alphagov/paas-terraform.git terraform \
-    && cd terraform \
-    && git checkout $TERRAFORM_TAG \
-    && make dev \
-    && mv bin/terraform /usr/local/bin \
-    && rm -rf /go \
-    && rm -rf /var/cache/apk/*
+    && wget https://releases.hashicorp.com/terraform/${TERRAFORM_VER}/${TERRAFORM_ZIP} -O /tmp/${TERRAFORM_ZIP} \
+    && echo "${TERRAFORM_SUM}  /tmp/${TERRAFORM_ZIP}" | sha256sum -c - \
+    && unzip /tmp/${TERRAFORM_ZIP} -d /usr/local/bin \
+    && rm /tmp/${TERRAFORM_ZIP}

--- a/terraform/terraform_spec.rb
+++ b/terraform/terraform_spec.rb
@@ -18,7 +18,7 @@ describe "Terraform image" do
   it "has the expected Terraform version" do
     expect(
       command("terraform version").stdout
-    ).to include("Terraform v0.7.5-dev")
+    ).to include("Terraform v0.7.10")
   end
 
   it "installs SSH" do


### PR DESCRIPTION
[#133751193 Enable datadog BOSH healthmonitor integration](https://www.pivotaltracker.com/story/show/133751193)

What?
-----

We want to upgrade terraform to use a patched version of the datadog provider.

Latest version is 0.7.10. There is no need to use our forked version of terraform anymore, so we go back to the code that downloads the official binary.

We were forced to upgrade the gem for docker-api for our tests, as the docker API has changed and the tests fail in the latest docker versions (~>1.12)

How to test?
-----------

Check Travis should pass.

You can optionally run `rake build:terraform spec:terraform`.

Who?
----

Anyone but @keymon or @saliceti