### PR TITLE
[#132820493] cf-acceptance-tests built from alpine

### DIFF
--- a/cf-acceptance-tests/Dockerfile
+++ b/cf-acceptance-tests/Dockerfile
@@ -1,9 +1,7 @@
-FROM golang:1.6.0-wheezy
+FROM golang:1.6-alpine
 
+RUN apk add --update curl unzip git bash && apk update && apk upgrade && rm -rf /var/cache/apk/*
 RUN curl -L 'https://cli.run.pivotal.io/stable?release=linux64-binary&version=6.21.1' | tar -zx -C /usr/local/bin
-RUN apt-get update \
-      && apt-get install -y --no-install-recommends unzip \
-      && rm -rf /var/lib/apt/lists/*
 
 RUN go get github.com/tools/godep
 RUN go get github.com/onsi/ginkgo/ginkgo

--- a/cf-acceptance-tests/README.md
+++ b/cf-acceptance-tests/README.md
@@ -8,7 +8,7 @@ helpers](https://github.com/cloudfoundry-incubator/cf-test-helpers):
 * `curl`
 * [`godep`](github.com/tools/godep)
 
-Based on the [golang](https://hub.docker.com/_/golang/) image.
+Based on the [golang](https://hub.docker.com/_/golang/) alpine image.
 
 ## Build locally
 


### PR DESCRIPTION
### What

Use alpine for cf-acceptance-tests container instead of debian wheezy. This reduces size from 670MB to 360.

### Testing
To build container and run tests: `bundle exec rake build:cf-acceptance-tests` and `bundle exec rake spec:cf-acceptance-tests`. All should pass. To test new container in tasks that use it - use [test-slim-acceptance-container](https://github.com/alphagov/paas-cf/tree/test-slim-acceptance-container) branch, or cherry pick this commit: https://github.com/alphagov/paas-cf/commit/fcbafea678a645029636b38d35b4465215beff30 . Apply to your pipeline and run. Make sure to run all acceptance tests.

### Who
not @mtekel