### PR TITLE
[#130188061] Add bash to bosh-cli

### DIFF
--- a/bosh-cli/Dockerfile
+++ b/bosh-cli/Dockerfile
@@ -2,4 +2,4 @@ FROM ruby:2.2-alpine
 
 RUN gem install bosh_cli -v 1.3232.0 --no-rdoc --no-ri
 
-RUN apk add --update openssl openssh-client file git && rm -rf /var/cache/apk/*
+RUN apk add --update bash openssl openssh-client file git && rm -rf /var/cache/apk/*

--- a/bosh-cli/bosh-cli_spec.rb
+++ b/bosh-cli/bosh-cli_spec.rb
@@ -31,6 +31,12 @@ describe "bosh-cli image" do
     expect(command('git --version').exit_status).to eq(0)
   end
 
+  it "has `bash` available" do
+    expect(
+      command("bash --version").exit_status
+    ).to eq(0)
+  end
+
   it "has a new enough version of openssl available" do
     # wget (from busybox) requires openssl to be able to connect to https sites.
 


### PR DESCRIPTION
# What

In order to build boshreleases that contain packages with pre_packagging steps, we need bash, as that's what bosh invokes for these scripts.[1]

[1] https://github.com/cloudfoundry/bosh/blob/stable-3262.9/bosh_cli/lib/cli/resources/package.rb#L193

# How to review
`rake build:bosh-cli spec:bosh-cli`

# Who can review
Anyone but @combor or me
