### PR TITLE
[#135801295] BOSH-CLI: bump aws cpi version to v62

### DIFF
--- a/bosh-init/Dockerfile
+++ b/bosh-init/Dockerfile
@@ -13,8 +13,8 @@ RUN apt-get install -y wget
 RUN wget -q -O /usr/local/bin/bosh-init --no-check-certificate ${BOSH_INIT_URL}
 RUN chmod +x /usr/local/bin/bosh-init
 
-ENV BOSH_AWS_CPI_URL https://bosh.io/d/github.com/cloudfoundry-incubator/bosh-aws-cpi-release?v=60
-ENV BOSH_AWS_CPI_CHECKSUM 8e40a9ff892204007889037f094a1b0d23777058
+ENV BOSH_AWS_CPI_URL https://bosh.io/d/github.com/cloudfoundry-incubator/bosh-aws-cpi-release?v=62
+ENV BOSH_AWS_CPI_CHECKSUM f36967927ceae09e5663a41fdda199edfe649dc6
 
 COPY bosh_init_cache /tmp/bosh_init_cache/
 RUN /tmp/bosh_init_cache/seed_bosh_init_cache.sh && \


### PR DESCRIPTION
### What

[Apply USN-3151-2 everywhere](https://www.pivotaltracker.com/n/projects/1275640/stories/135801295)

As a part of this story, we are going to bump aws cpi version to v62 in this container, to match the version we are using with BOSH, so that the cpi doesn't need to ge compiled every time we re-deploy BOSH.

### Reviewing
You can for example create a branch from https://github.com/alphagov/paas-cf/commits/upgrade-stemcell-135801295 and add there a commit that uses this new container. You should then have 0s compile time of the CPI when bosh-init deploys BOSH and concourse. Alternatively, you can trust that all scripting and tests work correctly and only compare the CPI link and sha1 hash in this PR vs [one to be used by bosh](https://github.com/alphagov/paas-cf/commit/06e1c4f37c0d41ff4ea723a6e44909fd48cd4893).

### Who
not @mtekel