### PR TITLE
WIP: [#135948443] Upgrade golang version for cf-acceptance-tests image

### DIFF
--- a/cf-acceptance-tests/Dockerfile
+++ b/cf-acceptance-tests/Dockerfile
@@ -7,3 +7,9 @@ RUN apt-get update \
 
 RUN go get github.com/tools/godep
 RUN go get github.com/onsi/ginkgo/ginkgo
+
+# FIXME: Remove this hack after https://github.com/cloudfoundry/cf-acceptance-tests/pull/145#issuecomment-274111140 is fixed
+RUN mkdir /bin/old && mv /bin/gzip /bin/old/gzip
+COPY gzip /bin
+RUN chmod +x /bin/gzip
+

--- a/cf-acceptance-tests/Dockerfile
+++ b/cf-acceptance-tests/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.6.0-wheezy
+FROM golang:1.7.4-wheezy
 
 RUN curl -L 'https://cli.run.pivotal.io/stable?release=linux64-binary&version=6.21.1' | tar -zx -C /usr/local/bin
 RUN apt-get update \

--- a/cf-acceptance-tests/cf-acceptance-tests_spec.rb
+++ b/cf-acceptance-tests/cf-acceptance-tests_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'docker'
 require 'serverspec'
 
-GO_VERSION="1.6"
+GO_VERSION="1.7.4"
 CF_CLI_VERSION="6.21.1"
 
 describe "cf-acceptance-tests image" do

--- a/cf-acceptance-tests/gzip
+++ b/cf-acceptance-tests/gzip
@@ -1,0 +1,9 @@
+#!/bin/bash
+case "$1" in
+	-*k*)
+		exec /bin/old/gzip "${1/k/}" < "$2" > "${2%%.gz}"
+		;;
+	*)
+		exec /bin/old/gzip "$@"
+		;;
+esac


### PR DESCRIPTION
## What

The latest Cloud Foundry upgrade (cf-release v245 to v250) means the
smoke and acceptance tests require golang 1.7+.

## How to review

You can run the usual local `rake build:all` and `rake spec:all`.

* Create a test branch and pin this version (`tag: upgrade-golang-for-acceptance-tests`) for smoke, acceptance, and custom acceptance test docker images in your pipeline.
* Deploy and check the tests pass.

Thinking out loud: If we pinned our docker image versions we wouldn't have to worry about breaking existing pipelines when merging to master.

## Who

Anyone but me or @keymon 