### PR TITLE
[#135948443] Use upstream's image for CATS

### DIFF
--- a/cf-acceptance-tests/Dockerfile
+++ b/cf-acceptance-tests/Dockerfile
@@ -8,7 +8,8 @@ RUN \
     curl \
     openssh-client \
     unzip \
-    git
+    git \
+  && rm -rf /var/lib/apt/lists/*
 
  ENV GOPATH /go
  ENV PATH /go/bin:/usr/local/go/bin:$PATH

--- a/cf-acceptance-tests/Dockerfile
+++ b/cf-acceptance-tests/Dockerfile
@@ -1,9 +1,30 @@
-FROM golang:1.6.0-wheezy
+FROM ubuntu:trusty
 
-RUN curl -L 'https://cli.run.pivotal.io/stable?release=linux64-binary&version=6.21.1' | tar -zx -C /usr/local/bin
-RUN apt-get update \
-      && apt-get install -y --no-install-recommends unzip \
-      && rm -rf /var/lib/apt/lists/*
+RUN \
+  apt-get update && \
+  apt-get -y install \
+    build-essential \
+    wget \
+    curl \
+    openssh-client \
+    unzip \
+    git
 
-RUN go get github.com/tools/godep
-RUN go get github.com/onsi/ginkgo/ginkgo
+ ENV GOPATH /go
+ ENV PATH /go/bin:/usr/local/go/bin:$PATH
+ RUN \
+  wget https://storage.googleapis.com/golang/go1.7.4.linux-amd64.tar.gz -P /tmp && \
+  tar xzvf /tmp/go1.7.4.linux-amd64.tar.gz -C /usr/local && \
+  mkdir $GOPATH && \
+  rm -rf /tmp/*
+
+# Install the cf CLI
+ARG version
+RUN wget -q -O cf.deb "https://cli.run.pivotal.io/stable?release=debian64&version=${version}&source=github-rel"
+RUN dpkg -i cf.deb
+
+# Install the container networking CLI plugin
+RUN wget -q -O /tmp/network-policy-plugin "https://github.com/cloudfoundry-incubator/netman-release/releases/download/v0.11.0/network-policy-plugin-linux64" && \
+  chmod +x /tmp/network-policy-plugin && \
+  cf install-plugin /tmp/network-policy-plugin -f && \
+  rm -rf /tmp/*

--- a/cf-acceptance-tests/Dockerfile
+++ b/cf-acceptance-tests/Dockerfile
@@ -23,8 +23,7 @@ RUN go get github.com/tools/godep
 RUN go get github.com/onsi/ginkgo/ginkgo
 
 # Install the cf CLI
-ARG version
-RUN wget -q -O cf.deb "https://cli.run.pivotal.io/stable?release=debian64&version=${version}&source=github-rel"
+RUN wget -q -O cf.deb "https://cli.run.pivotal.io/stable?release=debian64&version=6.21.1&source=github-rel"
 RUN dpkg -i cf.deb
 
 # Install the container networking CLI plugin

--- a/cf-acceptance-tests/Dockerfile
+++ b/cf-acceptance-tests/Dockerfile
@@ -19,6 +19,9 @@ RUN \
   mkdir $GOPATH && \
   rm -rf /tmp/*
 
+RUN go get github.com/tools/godep
+RUN go get github.com/onsi/ginkgo/ginkgo
+
 # Install the cf CLI
 ARG version
 RUN wget -q -O cf.deb "https://cli.run.pivotal.io/stable?release=debian64&version=${version}&source=github-rel"

--- a/cf-acceptance-tests/README.md
+++ b/cf-acceptance-tests/README.md
@@ -8,7 +8,8 @@ helpers](https://github.com/cloudfoundry-incubator/cf-test-helpers):
 * `curl`
 * [`godep`](github.com/tools/godep)
 
-Based on the [golang](https://hub.docker.com/_/golang/) image.
+Based on the [upstream image](https://hub.docker.com/r/relintdockerhubpushbot/cats-concourse-task/), which is
+hosted on [GitHub](https://github.com/cloudfoundry/cats-concourse-task).
 
 ## Build locally
 

--- a/cf-acceptance-tests/cf-acceptance-tests_spec.rb
+++ b/cf-acceptance-tests/cf-acceptance-tests_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'docker'
 require 'serverspec'
 
-GO_VERSION="1.6"
+GO_VERSION="1.7.4"
 CF_CLI_VERSION="6.21.1"
 
 describe "cf-acceptance-tests image" do


### PR DESCRIPTION
## What

The latest Cloud Foundry upgrade (cf-release v245 to v250) means the
smoke and acceptance tests require golang 1.7+. However, the upstream golang image did not support gzip 1.6, which is used in the new acceptance test code, so we have resorted to using a Dockerfile maintained by CloudFoundry.

## Dependencies

**Warning:** merging this will break the tests until the PR: https://github.com/alphagov/paas-cf/pull/735 is not deployed in prod, because we do not pin Docker image versions. 

See notes in https://github.com/alphagov/paas-cf/pull/735 for more details.

## How to review



You can run the usual local `rake build:cf-acceptance-tests` and `rake spec:cf-acceptance-tests`.

## Who

Anyone but me or @keymon 