### PR TITLE
[#161376949] TF: based on ruby with dogapi gem

### DIFF
--- a/terraform/Dockerfile
+++ b/terraform/Dockerfile
@@ -1,10 +1,11 @@
-FROM alpine:3.4
+FROM ruby:2.2-alpine
 
 ENV PATH $PATH:/usr/local/bin
 ENV TERRAFORM_VER 0.7.10
 ENV TERRAFORM_SUM a6da76d6228349855f7c503b769fb231e6b1009add5e5b2586ecb7624e9ecf15
 ENV TERRAFORM_ZIP terraform_${TERRAFORM_VER}_linux_amd64.zip
 
+RUN gem install dogapi -v 1.24.0
 RUN apk add --update openssl openssh-client ca-certificates && rm -rf /var/cache/apk/*
 RUN set -ex \
     && wget https://releases.hashicorp.com/terraform/${TERRAFORM_VER}/${TERRAFORM_ZIP} -O /tmp/${TERRAFORM_ZIP} \

--- a/terraform/terraform_spec.rb
+++ b/terraform/terraform_spec.rb
@@ -27,6 +27,12 @@ describe "Terraform image" do
     ).to include("OpenSSH")
   end
 
+  it "installs dogapi gem v1.24.0" do
+    expect(
+      command("gem list").stdout.strip
+    ).to include("dogapi (1.24.0)")  
+  end
+
   it "should not have binary directory larger than 200M" do
     expect(
       Integer(command("du -m /usr/local/bin").stdout.split.first)


### PR DESCRIPTION
Depends on https://github.com/alphagov/paas-docker-cloudfoundry-tools/pull/85 for travis to pass...

### What

Because of issue[1] with datadog library used by TF datadog provider,
we need to run additional scripts after TF run to finish up configuration.
These scripts are written in ruby and require dogapi gem. Modify TF
container to be based on ruby:alpine and add dogapi gem.

[1] https://github.com/zorkian/go-datadog-api/issues/56

### Testing
Run local tests (`rake spec:terraform`). Run pipeline with https://github.com/alphagov/paas-cf/commit/dba3715207e61ef24d35742a1528db5c3d626362 cherry-picked: this will make it use container from this branch. If the link doesn't work any more (e.g. because of re-basing), look for 'use ruby TF image' TMP commit in https://github.com/alphagov/paas-cf/commits/137701781_alert_on_smoktests .

### Who
not @mtekel or @combor 