### PR TITLE
Bump cerstrap to golang 1.7

### DIFF
--- a/certstrap/Dockerfile
+++ b/certstrap/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.5.3-alpine
+FROM golang:1.7-alpine
 
 ENV GIT_COMMIT 8b3cd66cfe2433e2e998c46a618eb09f732c2c2c
 ENV CERTSTRAP_VERSION 0.1.0

--- a/certstrap/certstrap_spec.rb
+++ b/certstrap/certstrap_spec.rb
@@ -12,7 +12,7 @@ describe "certstrap image" do
   }
 
   it "installs the right version of Alpine Linux" do
-    expect(os_version).to include("Alpine Linux 3.3")
+    expect(os_version).to include("Alpine Linux 3.4")
   end
 
   def os_version


### PR DESCRIPTION
### What
Golang 1.5.3 was based on alpine 3.3, which has dropped bash package. Golang
1.7 is based on alpine 3.4 which still has bash. There's currently only rc2
available of golang 1.8. We can bump versions again when we need to.

### Test
rake build:certstrap && rake spec:certstrap. Check travis state. You can cherry-pick https://github.com/alphagov/paas-cf/commit/131cb4794195eb861023ff6c1727cae981fb1faa and run your pipelines. Back up (download locally) and then delete certs and let certstrap generate ones. If you don't want to apply, recover old certs from local copy or previous version and upload them again.

### Who
not @mtekel