### PR TITLE
[#138486833] Terraform update to v 0.8.5

### DIFF
--- a/terraform/Dockerfile
+++ b/terraform/Dockerfile
@@ -1,8 +1,8 @@
 FROM alpine:3.4
 
 ENV PATH $PATH:/usr/local/bin
-ENV TERRAFORM_VER 0.7.10
-ENV TERRAFORM_SUM a6da76d6228349855f7c503b769fb231e6b1009add5e5b2586ecb7624e9ecf15
+ENV TERRAFORM_VER 0.8.5
+ENV TERRAFORM_SUM 4b4324e354c26257f0b830eacb0e7cc7e2ced017d78855f74cb9377f1abf1dd7
 ENV TERRAFORM_ZIP terraform_${TERRAFORM_VER}_linux_amd64.zip
 
 RUN apk add --update openssl openssh-client ca-certificates && rm -rf /var/cache/apk/*

--- a/terraform/terraform_spec.rb
+++ b/terraform/terraform_spec.rb
@@ -18,7 +18,7 @@ describe "Terraform image" do
   it "has the expected Terraform version" do
     expect(
       command("terraform version").stdout
-    ).to include("Terraform v0.7.10")
+    ).to include("Terraform v0.8.5")
   end
 
   it "installs SSH" do


### PR DESCRIPTION
# What
As we refactored terraform config in https://github.com/alphagov/paas-cf/commit/965ae1e977c8298027399e4d09277aa531e7a05a
we started to be hitting https://github.com/hashicorp/terraform/issues/5301 again.

We need to update to a newer terraform version to successfully run terraform in our pipeline.

# How to test 

This needs to be reviewed and merged in conjunction with alphagov/paas-cf#744

# Who
Not @alext or @combor  