### PR TITLE
[#137881471]Update cf cli to v 6.23.1

### DIFF
--- a/cf-cli/Dockerfile
+++ b/cf-cli/Dockerfile
@@ -4,5 +4,5 @@ ENV PACKAGES "unzip curl openssl ca-certificates git ruby ruby-json"
 
 RUN apk add --update $PACKAGES && rm -rf /var/cache/apk/*
 
-RUN curl -L 'https://cli.run.pivotal.io/stable?release=linux64-binary&version=6.21.1' | tar -zx -C /usr/local/bin
+RUN curl -L 'https://cli.run.pivotal.io/stable?release=linux64-binary&version=6.23.1' | tar -zx -C /usr/local/bin
 RUN curl -L 'https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64' -o /usr/local/bin/jq && chmod +x /usr/local/bin/jq

--- a/cf-cli/cf-acceptance-tests_spec.rb
+++ b/cf-cli/cf-acceptance-tests_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'docker'
 require 'serverspec'
 
-CF_CLI_VERSION="6.21.1"
+CF_CLI_VERSION="6.23.1"
 
 describe "cf-cli image" do
   before(:all) {


### PR DESCRIPTION
## What
Bump version of cf-cli used in our governmentpaas/cf-cli container to
latest (currently v6.23.1).

Update brings useful features:
- Where available, error messages from 5xx responses from API endpoints now include the request id, which can be helpful for platform operators to look up details on the interaction in CF's internal logs.
- We are in the process of creating a more consistent user experience; our goal is to standardize UI output. For example, warnings and errors will consistently be outputted to stderr instead of stdout. As we iterate through the list of commands, we are also focusing on improving performance and stability.

- This release introduces commands to run, terminate and list tasks, available from CF release v247 
- `delete-space` now takes an optional org parameter to allow deletion of a space without targeting it.
- `logs` and `push` now use the doppler logging endpoint published by the CC API (/v2/info), as opposed to extracting it from the recently deprecated logging endpoint entry.
- a lot of improvements to help messages for various commands

Also we've got external request to bump the version: https://github.com/alphagov/paas-docker-cloudfoundry-tools/issues/81

## How to test

- run the create pipeline from `137881471_update_cf_cli_6_23_1` branch on `paas-cf`
- **Warning:** Important info from release notes - `For example, warnings and errors will consistently be outputted to stderr instead of stdout.` This may affect all code that is parsing `cf cli` output. We need to test it carefully. 

## Who

Not @combor



