### PR TITLE
[bugfix] Remove "based on" from READMEs

### DIFF
--- a/awscli/README.md
+++ b/awscli/README.md
@@ -4,8 +4,6 @@ command line.
 Also curl with SSL and openssl support is included, to allow scripting HTTP
 calls if necessary (e.g. query metadata)
 
-Based on [alpine](https://hub.docker.com/_/alpine/) image.
-
 ## Build locally
 
 ```

--- a/bosh-cli/README.md
+++ b/bosh-cli/README.md
@@ -4,8 +4,6 @@ Container for running Bosh SSH.
 * `BOSH` CLI
 * `SSH`
 
-Based on the [ruby:slim](https://hub.docker.com/_/ruby/) image.
-
 ## Build locally
 
 ```

--- a/cf-cli/README.md
+++ b/cf-cli/README.md
@@ -7,8 +7,6 @@ It includes some other packages commonly used when deploying CF apps:
 * `unzip`
 * `git`
 
-Based on the [wheezy](https://hub.docker.com/_/debian/) image.
-
 ## Build locally
 
 ```

--- a/cf-uaac/README.md
+++ b/cf-uaac/README.md
@@ -3,8 +3,6 @@ Container for running uaac cli.
 
 * `uaac` CLI
 
-Based on the [ruby:slim](https://hub.docker.com/_/ruby/) image.
-
 ## Build locally
 
 ```

--- a/curl-ssl/README.md
+++ b/curl-ssl/README.md
@@ -2,8 +2,6 @@ Includes curl with SSL and openssl support, including the `openssl` command.
 
 It also includes the ca-certificates.
 
-Based on [alpine](https://hub.docker.com/_/alpine/) image.
-
 ## Build locally
 
 ```

--- a/git-ssh/README.md
+++ b/git-ssh/README.md
@@ -2,8 +2,6 @@ Installs Git with OpenSSH
 
 Git also includes by default curl, OpenSSL and ca-certificates.
 
-Based on [alpine](https://hub.docker.com/_/alpine/) image.
-
 ## Build locally
 
 ```

--- a/json-minify/README.md
+++ b/json-minify/README.md
@@ -1,8 +1,5 @@
 Container for Ruby implemenation of json-minify.
 
-
-Based on the [ruby:alpine](https://hub.docker.com/r/library/ruby/tags/) image.
-
 ## Build locally
 
 ```

--- a/psql/README.md
+++ b/psql/README.md
@@ -1,7 +1,5 @@
 Provides *psql* Postgres client.
 
-Based on [alpine](https://hub.docker.com/_/alpine/) image.
-
 ## Build locally
 
 ```

--- a/self-update-pipelines/README.md
+++ b/self-update-pipelines/README.md
@@ -6,8 +6,6 @@ This includes all the software for this task to run.
 * `ruby` and `curl`: Included on `ruby:slim`
 * `make`
 
-Based on the [wheezy](https://hub.docker.com/_/ruby/) image.
-
 ## Build locally
 
 ```


### PR DESCRIPTION
## What

I noticed this while reviewing #87

We're not very good at maintaining the "Based on XXX image" messages in the
READMEs of each of our containers. I don't think there's much value in
providing this, since the correct information is the in the `Dockerfile` and
people should look there before deciding whether a container is appropriate
for their use.

```
➜  paas-docker-cloudfoundry-tools git:(master) for i in */README.md; do ack Based ${i} && ack FROM $(dirname $i)/Dockerfile; echo; done
Based on [alpine](https://hub.docker.com/_/alpine/) image.
FROM governmentpaas/curl-ssl

Based on the [ruby:slim](https://hub.docker.com/_/ruby/) image.
FROM ruby:2.2-alpine

Based on the [upstream image](https://hub.docker.com/r/relintdockerhubpushbot/cats-concourse-task/), which is
FROM ubuntu:trusty

Based on the [wheezy](https://hub.docker.com/_/debian/) image.
FROM alpine:3.3

Based on the [ruby:slim](https://hub.docker.com/_/ruby/) image.
FROM ruby:2.2-alpine

Based on [alpine](https://hub.docker.com/_/alpine/) image.
FROM alpine:3.3

Based on [alpine](https://hub.docker.com/_/alpine/) image.
FROM alpine:3.3

Based on the [ruby:alpine](https://hub.docker.com/r/library/ruby/tags/) image.
FROM ruby:2.3-alpine

Based on [alpine](https://hub.docker.com/_/alpine/) image.
FROM alpine:3.3

Based on the [wheezy](https://hub.docker.com/_/ruby/) image.
FROM ruby:2.2-slim
```

## How to review

Confirm that the documentation changes make sense.

## Who can review

Not @dcarley