### PR TITLE
[#121934253] cf-cli: Add blue-green-deploy plugin

### DIFF
--- a/cf-cli/Dockerfile
+++ b/cf-cli/Dockerfile
@@ -1,8 +1,9 @@
 FROM alpine:3.3
 
 ENV PACKAGES "unzip curl openssl ca-certificates git ruby ruby-json"
+ENV CF_CLI_VERSION "6.23.1"
 
 RUN apk add --update $PACKAGES && rm -rf /var/cache/apk/*
 
-RUN curl -L 'https://cli.run.pivotal.io/stable?release=linux64-binary&version=6.23.1' | tar -zx -C /usr/local/bin
+RUN curl -L "https://cli.run.pivotal.io/stable?release=linux64-binary&version=${CF_CLI_VERSION}" | tar -zx -C /usr/local/bin
 RUN curl -L 'https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64' -o /usr/local/bin/jq && chmod +x /usr/local/bin/jq

--- a/cf-cli/Dockerfile
+++ b/cf-cli/Dockerfile
@@ -2,9 +2,19 @@ FROM alpine:3.3
 
 ENV PACKAGES "unzip curl openssl ca-certificates git ruby ruby-json libc6-compat"
 ENV CF_CLI_VERSION "6.23.1"
+ENV CF_BGD_VERSION "1.1.0"
+ENV CF_BGD_CHECKSUM "fe6ebd3c2dc3a287db0d31eeaed200d1a27117d9a6ddd875de561e4a6e8858d1"
+ENV CF_BGD_TEMPFILE "/tmp/blue-green-deploy.linux64"
 
 RUN apk add --update $PACKAGES && rm -rf /var/cache/apk/*
 RUN ln -s /lib/ /lib64 # FIXME: Remove for Alpine >= 3.6
 
 RUN curl -L "https://cli.run.pivotal.io/stable?release=linux64-binary&version=${CF_CLI_VERSION}" | tar -zx -C /usr/local/bin
 RUN curl -L 'https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64' -o /usr/local/bin/jq && chmod +x /usr/local/bin/jq
+
+RUN curl -L -o "${CF_BGD_TEMPFILE}" \
+  "https://github.com/bluemixgaragelondon/cf-blue-green-deploy/releases/download/v${CF_BGD_VERSION}/blue-green-deploy.linux64" \
+  && echo "${CF_BGD_CHECKSUM}  ${CF_BGD_TEMPFILE}" | sha256sum -c - \
+  && chmod +x "${CF_BGD_TEMPFILE}" \
+  && cf install-plugin -f "${CF_BGD_TEMPFILE}" \
+  && rm "${CF_BGD_TEMPFILE}"

--- a/cf-cli/Dockerfile
+++ b/cf-cli/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.3
 
-ENV PACKAGES "unzip curl openssl ca-certificates git ruby ruby-json"
+ENV PACKAGES "unzip curl openssl ca-certificates git ruby ruby-json libc6-compat"
 ENV CF_CLI_VERSION "6.23.1"
 
 RUN apk add --update $PACKAGES && rm -rf /var/cache/apk/*

--- a/cf-cli/Dockerfile
+++ b/cf-cli/Dockerfile
@@ -4,6 +4,7 @@ ENV PACKAGES "unzip curl openssl ca-certificates git ruby ruby-json libc6-compat
 ENV CF_CLI_VERSION "6.23.1"
 
 RUN apk add --update $PACKAGES && rm -rf /var/cache/apk/*
+RUN ln -s /lib/ /lib64 # FIXME: Remove for Alpine >= 3.6
 
 RUN curl -L "https://cli.run.pivotal.io/stable?release=linux64-binary&version=${CF_CLI_VERSION}" | tar -zx -C /usr/local/bin
 RUN curl -L 'https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64' -o /usr/local/bin/jq && chmod +x /usr/local/bin/jq

--- a/cf-cli/cf-acceptance-tests_spec.rb
+++ b/cf-cli/cf-acceptance-tests_spec.rb
@@ -15,6 +15,11 @@ describe "cf-cli image" do
     ).to match(/cf version #{CF_CLI_VERSION}/)
   end
 
+  it "has blue-green-deploy plugin available" do
+    cmd = command("cf blue-green-deploy --help")
+    expect(cmd.exit_status).to eq(0)
+  end
+
   it "has curl available" do
     expect(
       command("curl --version").exit_status


### PR DESCRIPTION
## What

We want to use this plugin within our alphagov/paas-cf pipeline. At the
moment it will only be for the healthcheck app, which we never want to have
any downtime because we use it for monitoring and automated tests. We may
choose to use it for other apps in the future if this proves successful.

## How to review

- read the individual commit messages for more information about the changes
- test it with the changes in alphagov/paas-cf#779

## Who can review

Not @dcarley