### PR TITLE
bump spruce to version 1.8.9

### DIFF
--- a/spruce/Dockerfile
+++ b/spruce/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.4
 
-ENV SPRUCE_VERSION 1.5.0
+ENV SPRUCE_VERSION 1.8.9
 
 RUN apk add --update wget ca-certificates \
   && wget https://github.com/geofffranks/spruce/releases/download/v${SPRUCE_VERSION}/spruce-linux-amd64 \

--- a/spruce/spruce_spec.rb
+++ b/spruce/spruce_spec.rb
@@ -3,7 +3,7 @@ require 'docker'
 require 'serverspec'
 
 SPRUCE_BIN = "/usr/local/bin/spruce"
-SPRUCE_VERSION = "1.5.0"
+SPRUCE_VERSION = "1.8.9"
 ALPINE_VERSION = "3.4"
 
 describe "spruce image" do


### PR DESCRIPTION
Could you please consider upgrading spruce to recent version. We use this feature https://github.com/geofffranks/spruce/issues/175, introduced in [1.8.2](https://github.com/geofffranks/spruce/releases/tag/v1.8.2)

Thanks