### PR TITLE
[#139179971] Upgrade cf-cli to 6.25.0 in cf-acceptance-tests

### DIFF
--- a/cf-acceptance-tests/Dockerfile
+++ b/cf-acceptance-tests/Dockerfile
@@ -23,8 +23,9 @@ RUN go get github.com/tools/godep
 RUN go get github.com/onsi/ginkgo/ginkgo
 
 # Install the cf CLI
-RUN wget -q -O cf.deb "https://cli.run.pivotal.io/stable?release=debian64&version=6.21.1&source=github-rel"
-RUN dpkg -i cf.deb
+RUN wget -q -O cf.deb "https://cli.run.pivotal.io/stable?release=debian64&version=6.25.0&source=github-rel" && \
+    dpkg -i cf.deb && \
+    rm -f cf.deb
 
 # Install the container networking CLI plugin
 RUN wget -q -O /tmp/network-policy-plugin "https://github.com/cloudfoundry-incubator/netman-release/releases/download/v0.11.0/network-policy-plugin-linux64" && \

--- a/cf-acceptance-tests/cf-acceptance-tests_spec.rb
+++ b/cf-acceptance-tests/cf-acceptance-tests_spec.rb
@@ -3,7 +3,7 @@ require 'docker'
 require 'serverspec'
 
 GO_VERSION="1.7.4"
-CF_CLI_VERSION="6.21.1"
+CF_CLI_VERSION="6.25.0"
 
 describe "cf-acceptance-tests image" do
   before(:all) {


### PR DESCRIPTION
[#139179971 Upgrade CF to >= v252](https://www.pivotaltracker.com/story/show/139179971)

What?
-----

While upgrading to CF v253, the acceptance tests use the command `cf run-task`[1] which was included in cf-cli 6.23.0[2]

We decided upgrade to the latest client version 6.25.0

[1] http://cli.cloudfoundry.org/es-ES/cf/run-task.html
[2] https://github.com/cloudfoundry/cli/releases/tag/v6.23.0
[3] https://github.com/cloudfoundry/cli/releases/tag/v6.25.0


How to review?
-------------

Code review shall be enough

Who?
---

Anyone but @keymon or @csaliceti