### PR TITLE
[#142400337] Upgrade cf-cli to 6.26 in cf-cli and cf-acceptance-tests containers.

### DIFF
--- a/cf-acceptance-tests/Dockerfile
+++ b/cf-acceptance-tests/Dockerfile
@@ -23,7 +23,7 @@ RUN go get github.com/tools/godep
 RUN go get github.com/onsi/ginkgo/ginkgo
 
 # Install the cf CLI
-RUN wget -q -O cf.deb "https://cli.run.pivotal.io/stable?release=debian64&version=6.25.0&source=github-rel" && \
+RUN wget -q -O cf.deb "https://cli.run.pivotal.io/stable?release=debian64&version=6.26.0&source=github-rel" && \
     dpkg -i cf.deb && \
     rm -f cf.deb
 

--- a/cf-acceptance-tests/cf-acceptance-tests_spec.rb
+++ b/cf-acceptance-tests/cf-acceptance-tests_spec.rb
@@ -3,7 +3,7 @@ require 'docker'
 require 'serverspec'
 
 GO_VERSION="1.7.4"
-CF_CLI_VERSION="6.25.0"
+CF_CLI_VERSION="6.26.0"
 
 describe "cf-acceptance-tests image" do
   before(:all) {

--- a/cf-cli/Dockerfile
+++ b/cf-cli/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.3
 
 ENV PACKAGES "unzip curl openssl ca-certificates git ruby ruby-json libc6-compat"
-ENV CF_CLI_VERSION "6.23.1"
+ENV CF_CLI_VERSION "6.26.0"
 ENV CF_BGD_VERSION "1.1.0"
 ENV CF_BGD_CHECKSUM "fe6ebd3c2dc3a287db0d31eeaed200d1a27117d9a6ddd875de561e4a6e8858d1"
 ENV CF_BGD_TEMPFILE "/tmp/blue-green-deploy.linux64"

--- a/cf-cli/cf-acceptance-tests_spec.rb
+++ b/cf-cli/cf-acceptance-tests_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'docker'
 require 'serverspec'
 
-CF_CLI_VERSION="6.23.1"
+CF_CLI_VERSION="6.26.0"
 
 describe "cf-cli image" do
   before(:all) {


### PR DESCRIPTION
## What

Update both the cf-cli and cf-acceptance tests containers so that we're using a
consistent version throughout our pipeline.

cf-cli 6.26 include the fix for the 2GB ssh issue.

## How to review

Review as part of alphagov/paas-cf#900. 

🚨  Do not merge this, until alphagov/paas-cf#900 has been merged and deployed to production