### PR TITLE
WIP [#132565531] Update bosh-init to v0.0.100

### DIFF
--- a/bosh-init/Dockerfile
+++ b/bosh-init/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:14.04
 
-ENV BOSH_INIT_VERSION 0.0.95
+ENV BOSH_INIT_VERSION 0.0.100
 ENV BOSH_INIT_URL https://s3.amazonaws.com/bosh-init-artifacts/bosh-init-${BOSH_INIT_VERSION}-linux-amd64
 ENV BOSH_INIT_PACKAGES "build-essential zlibc zlib1g-dev ruby ruby-dev openssl libxslt1-dev libxml2-dev \
     libssl-dev libreadline6 libreadline6-dev libyaml-dev libsqlite3-dev sqlite3"

--- a/bosh-init/bosh-init_spec.rb
+++ b/bosh-init/bosh-init_spec.rb
@@ -4,7 +4,7 @@ require 'serverspec'
 
 BOSH_INIT_PACKAGES = "build-essential zlibc zlib1g-dev ruby ruby-dev openssl libxslt1-dev libxml2-dev \
     libssl-dev libreadline6 libreadline6-dev libyaml-dev libsqlite3-dev sqlite3"
-BOSH_INIT_VERSION = "0.0.95-365cb4e-2016-06-29T23:30:18Z"
+BOSH_INIT_VERSION = "0.0.100-a5c1605-2017-02-14T23:33:52Z"
 
 describe "bosh-init image" do
   before(:all) {


### PR DESCRIPTION
## What

Story: [Upgrade to BOSH >= 261.3](https://www.pivotaltracker.com/story/show/132565531)

Due to a bug in bosh-init and more recent versions of stemcell we have to update to the version 0.0.100+.

## How to review

* Build and test locally
* Test with temp commit on the relevant paas-bootstrap PR
* The bootstrap pipeline should be able to build BOSH

## After merging

* Finalise TEMP commit in paas-bootstrap PR and replace the branch reference with the merge commit SHA

## Who can review

Not @combor or me
