### PR TITLE
Compose integration tests

### DIFF
--- a/cf-acceptance-tests/Dockerfile
+++ b/cf-acceptance-tests/Dockerfile
@@ -1,4 +1,5 @@
 FROM ubuntu:trusty
+ENV DEBIAN_FRONTEND noninteractive
 
 RUN \
   apt-get update && \
@@ -14,8 +15,8 @@ RUN \
  ENV GOPATH /go
  ENV PATH /go/bin:/usr/local/go/bin:$PATH
  RUN \
-  wget https://storage.googleapis.com/golang/go1.7.4.linux-amd64.tar.gz -P /tmp && \
-  tar xzvf /tmp/go1.7.4.linux-amd64.tar.gz -C /usr/local && \
+  wget https://storage.googleapis.com/golang/go1.8.3.linux-amd64.tar.gz -P /tmp && \
+  tar xzvf /tmp/go1.8.3.linux-amd64.tar.gz -C /usr/local && \
   mkdir $GOPATH && \
   rm -rf /tmp/*
 
@@ -28,7 +29,7 @@ RUN wget -q -O cf.deb "https://cli.run.pivotal.io/stable?release=debian64&versio
     rm -f cf.deb
 
 # Install the container networking CLI plugin
-RUN wget -q -O /tmp/network-policy-plugin "https://github.com/cloudfoundry-incubator/netman-release/releases/download/v0.11.0/network-policy-plugin-linux64" && \
+RUN wget -q -O /tmp/network-policy-plugin "https://github.com/cloudfoundry-incubator/cf-networking-release/releases/download/v1.2.0/network-policy-plugin-linux64" && \
   chmod +x /tmp/network-policy-plugin && \
   cf install-plugin /tmp/network-policy-plugin -f && \
   rm -rf /tmp/*

--- a/cf-acceptance-tests/cf-acceptance-tests_spec.rb
+++ b/cf-acceptance-tests/cf-acceptance-tests_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'docker'
 require 'serverspec'
 
-GO_VERSION="1.7.4"
+GO_VERSION="1.8.3"
 CF_CLI_VERSION="6.26.0"
 
 describe "cf-acceptance-tests image" do


### PR DESCRIPTION
## What

This adds a version of cf-acceptance-tests that uses Go 1.8.3, this is needed for some of the tests in paas-compose-broker

## How to test
1. Clone the repo
1. Switch to this branch
1. cd cf-acceptance-tests-1.8
1. docker build -t cf-acceptance-tests-1.8 .
1. docker run -i -t cf-acceptance-tests-1.8 go version and confirm it matches go1.8.3 `go version go1.8.3 linux/amd64`

## Who can review

Not me
