### PR TITLE
Update spruce to 1.12.1

### DIFF
--- a/spruce/Dockerfile
+++ b/spruce/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.4
 
-ENV SPRUCE_VERSION 1.8.9
+ENV SPRUCE_VERSION 1.12.1
 
 RUN apk add --update wget ca-certificates \
   && wget https://github.com/geofffranks/spruce/releases/download/v${SPRUCE_VERSION}/spruce-linux-amd64 \

--- a/spruce/spruce_spec.rb
+++ b/spruce/spruce_spec.rb
@@ -3,7 +3,7 @@ require 'docker'
 require 'serverspec'
 
 SPRUCE_BIN = "/usr/local/bin/spruce"
-SPRUCE_VERSION = "1.8.9"
+SPRUCE_VERSION = "1.12.1"
 ALPINE_VERSION = "3.4"
 
 describe "spruce image" do


### PR DESCRIPTION
## What
This PR updates the version of spruce to the latest version. This
enables `(( static_IPS ))` `(( vault ))` `--go-patch`, `--no-eval`
`spruce diff` options.

It also keeps up up to date with upstream.

## How to test

Code review
Build locally

## Who can merge

Not @LeePorte