### PR TITLE
[#150926071] Upgrade AWS CLI tool to the latest version

### DIFF
--- a/awscli/Dockerfile
+++ b/awscli/Dockerfile
@@ -1,6 +1,6 @@
 FROM governmentpaas/curl-ssl
 
-ENV AWSCLI_VERSION "1.10.38"
+ENV AWSCLI_VERSION "1.11.164"
 ENV PACKAGES "groff less python py-pip"
 
 RUN apk add --update $PACKAGES \

--- a/awscli/awscli_spec.rb
+++ b/awscli/awscli_spec.rb
@@ -5,7 +5,7 @@ require 'serverspec'
 AWSCLI_PACKAGES = "curl openssl ca-certificates less"
 
 AWSCLI_BIN = "/usr/bin/aws"
-AWSCLI_VERSION = "1.10.38"
+AWSCLI_VERSION = "1.11.164"
 
 describe "awscli image" do
   before(:all) {


### PR DESCRIPTION
## What

We'd like to use some functionality (`start-db-instance` and
`stop-db-instance`) in our pipeline. The current version does not cover
these.

We're upgrading to the latest available version on pip as frankly, we
don't see any reason not to.

## How to review

- Build locally
- Test locally