### PR TITLE
[#153091168] Add autopilot plugin to cf-cli docker image

### DIFF
--- a/cf-cli/Dockerfile
+++ b/cf-cli/Dockerfile
@@ -5,6 +5,9 @@ ENV CF_CLI_VERSION "6.26.0"
 ENV CF_BGD_VERSION "1.1.0"
 ENV CF_BGD_CHECKSUM "fe6ebd3c2dc3a287db0d31eeaed200d1a27117d9a6ddd875de561e4a6e8858d1"
 ENV CF_BGD_TEMPFILE "/tmp/blue-green-deploy.linux64"
+ENV CF_AUTOPILOT_VERSION "0.0.3"
+ENV CF_AUTOPILOT_CHECKSUM "c3b5a38ba7a9817e12d6ab4c98418d707c49c1d3eb68e5a79e701531bd8fa1cd"
+ENV CF_AUTOPILOT_TEMPFILE "/tmp/autopilot-linux"
 
 RUN apk add --update $PACKAGES && rm -rf /var/cache/apk/*
 RUN ln -s /lib/ /lib64 # FIXME: Remove for Alpine >= 3.6
@@ -18,3 +21,10 @@ RUN curl -L -o "${CF_BGD_TEMPFILE}" \
   && chmod +x "${CF_BGD_TEMPFILE}" \
   && cf install-plugin -f "${CF_BGD_TEMPFILE}" \
   && rm "${CF_BGD_TEMPFILE}"
+
+RUN curl -L -o "${CF_AUTOPILOT_TEMPFILE}" \
+  "https://github.com/contraband/autopilot/releases/download/${CF_AUTOPILOT_VERSION}/autopilot-linux" \
+  && echo "${CF_AUTOPILOT_CHECKSUM}  ${CF_AUTOPILOT_TEMPFILE}" | sha256sum -c - \
+  && chmod +x "${CF_AUTOPILOT_TEMPFILE}" \
+  && cf install-plugin -f "${CF_AUTOPILOT_TEMPFILE}" \
+  && rm "${CF_AUTOPILOT_TEMPFILE}"

--- a/cf-cli/README.md
+++ b/cf-cli/README.md
@@ -16,7 +16,7 @@ It also includes some commonly-used `cf` plugins:
 
 ```
 $ cd cf-cli
-$ docker build -t cf-cly .
+$ docker build -t cf-cli .
 ```
 
 ## Run

--- a/cf-cli/README.md
+++ b/cf-cli/README.md
@@ -1,11 +1,16 @@
 Container for running CloudFoundry client.
 
-It includes some other packages commonly used when deploying CF apps:
+It includes some packages commonly used when deploying CF apps:
 
 * `cf` CLI
 * `curl`
 * `unzip`
 * `git`
+
+It also includes some commonly-used `cf` plugins:
+
+* [blue-green-deploy](https://github.com/bluemixgaragelondon/cf-blue-green-deploy)
+* [autopilot](https://github.com/contraband/autopilot)
 
 ## Build locally
 

--- a/cf-cli/cf-acceptance-tests_spec.rb
+++ b/cf-cli/cf-acceptance-tests_spec.rb
@@ -20,6 +20,11 @@ describe "cf-cli image" do
     expect(cmd.exit_status).to eq(0)
   end
 
+  it "has autopilot plugin available" do
+    cmd = command("cf zero-downtime-push --help")
+    expect(cmd.exit_status).to eq(0)
+  end
+
   it "has curl available" do
     expect(
       command("curl --version").exit_status


### PR DESCRIPTION
## What

We are updating the product page deployment to deploy with a host of `www.cloud.service.gov.uk` (see https://github.com/alphagov/paas-product-page/pull/44.) For this we need the [autopilot](https://github.com/contraband/autopilot) `cf` plugin to be available in `cf-cli` Docker image [being used](https://github.com/alphagov/paas-release-ci/blob/master/pipelines/deploy-app.yml#L91-L98).

## How to review

Code review

## Who can review

Not @46bit @camelpunch 