### PR TITLE
[#153366899] Install jq in the awscli Docker image

### DIFF
--- a/awscli/Dockerfile
+++ b/awscli/Dockerfile
@@ -1,10 +1,9 @@
 FROM governmentpaas/curl-ssl
 
 ENV AWSCLI_VERSION "1.11.164"
-ENV PACKAGES "groff less python py-pip"
+ENV PACKAGES "groff less python py-pip jq=1.5-r1"
 
 RUN apk add --update $PACKAGES \
     && pip install awscli==$AWSCLI_VERSION \
     && apk --purge -v del py-pip \
     && rm -rf /var/cache/apk/*
-

--- a/awscli/awscli_spec.rb
+++ b/awscli/awscli_spec.rb
@@ -45,4 +45,10 @@ describe "awscli image" do
     end
   end
 
+  it "has jq available" do
+    cmd = command("jq --version")
+    expect(cmd.exit_status).to eq(0)
+    expect(cmd.stdout).to match(/^jq-1.5/)
+  end
+
 end


### PR DESCRIPTION
## What

jq is a useful additon as the AWS cli often returns with a JSON response which
is easier to parse using jq (especially when we need multiple properties from
the same response).

This PR is needed for https://github.com/alphagov/paas-bootstrap/pull/107.

## How to review

1. Build the Docker image

```
cd awscli
docker build -t awscli .
cd ..
rspec awscli/awscli_spec.rb
```

## Who can review

Not @bandesz

