### PR TITLE
[#153366899] Upgrade AWS cli to 1.14.10

### DIFF
--- a/awscli/Dockerfile
+++ b/awscli/Dockerfile
@@ -1,6 +1,6 @@
 FROM governmentpaas/curl-ssl
 
-ENV AWSCLI_VERSION "1.11.164"
+ENV AWSCLI_VERSION "1.14.10"
 ENV PACKAGES "groff less python py-pip jq=1.5-r1"
 
 RUN apk add --update $PACKAGES \

--- a/awscli/awscli_spec.rb
+++ b/awscli/awscli_spec.rb
@@ -5,7 +5,7 @@ require 'serverspec'
 AWSCLI_PACKAGES = "curl openssl ca-certificates less"
 
 AWSCLI_BIN = "/usr/bin/aws"
-AWSCLI_VERSION = "1.11.164"
+AWSCLI_VERSION = "1.14.10"
 
 describe "awscli image" do
   before(:all) {


### PR DESCRIPTION
## What

We are using an old version and we need the latest features.

This PR is needed for https://github.com/alphagov/paas-bootstrap/pull/107.

## How to review

1. Build the Docker image

```
cd awscli
docker build -t awscli .
cd ..
rspec awscli/awscli_spec.rb
```

## Who can review

Not @bandesz

