### PR TITLE
bump spruce to 1.14 and alpine to 3.7

### DIFF
--- a/spruce/Dockerfile
+++ b/spruce/Dockerfile
@@ -1,6 +1,6 @@
-FROM alpine:3.4
+FROM alpine:3.7
 
-ENV SPRUCE_VERSION 1.12.1
+ENV SPRUCE_VERSION 1.14.0
 
 RUN apk add --update wget ca-certificates \
   && wget https://github.com/geofffranks/spruce/releases/download/v${SPRUCE_VERSION}/spruce-linux-amd64 \

--- a/spruce/spruce_spec.rb
+++ b/spruce/spruce_spec.rb
@@ -3,8 +3,8 @@ require 'docker'
 require 'serverspec'
 
 SPRUCE_BIN = "/usr/local/bin/spruce"
-SPRUCE_VERSION = "1.12.1"
-ALPINE_VERSION = "3.4"
+SPRUCE_VERSION = "1.14.0"
+ALPINE_VERSION = "3.7"
 
 describe "spruce image" do
   before(:all) {


### PR DESCRIPTION
Using the latest spruce version, doesn't require usage of ! to escape  BOSH/Concourse
variables.