### PR TITLE
bosh-shell improvements

### DIFF
--- a/bosh-shell/Dockerfile
+++ b/bosh-shell/Dockerfile
@@ -4,7 +4,9 @@ RUN gem install bosh_cli -v 1.3262.26.0 --no-rdoc --no-ri
 
 RUN apk add --update bash openssl openssh-client file git && rm -rf /var/cache/apk/*
 
-COPY startup.sh /startup.sh
 COPY bosh-ssh /usr/local/bin
+COPY bosh_wrapper.sh /usr/local/bin
+COPY bosh_wrapper.rc /
+COPY startup.sh /startup.sh
 
 ENTRYPOINT /startup.sh

--- a/bosh-shell/bosh-ssh
+++ b/bosh-shell/bosh-ssh
@@ -1,17 +1,4 @@
 #!/bin/bash
 
-set -eu
-
-if [ $# -eq 0 ]
-then
-    echo "Usage: $(basename "$0") VM/INDEX"
-    exit 1
-fi
-
-target=$1
-
-exec bosh ssh \
-   "$target" \
-   --gateway_host "$BOSH_IP" \
-   --gateway_user vcap \
-   --gateway_identity_file /tmp/bosh_id_rsa
+echo 'deprecated: use `bosh ssh` as normal'
+exit 2

--- a/bosh-shell/bosh_wrapper.rc
+++ b/bosh-shell/bosh_wrapper.rc
@@ -1,0 +1,1 @@
+alias bosh=bosh_wrapper.sh

--- a/bosh-shell/bosh_wrapper.sh
+++ b/bosh-shell/bosh_wrapper.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+if [ "$1" == "ssh" ]; then
+  shift 1
+  exec bosh ssh \
+    --gateway_host "$BOSH_IP" \
+    --gateway_user vcap \
+    --gateway_identity_file /tmp/bosh_id_rsa \
+    $*
+else
+  exec bosh $*
+fi

--- a/bosh-shell/startup.sh
+++ b/bosh-shell/startup.sh
@@ -22,8 +22,4 @@ bosh target localhost
 bosh download manifest "${BOSH_DEPLOYMENT}" "${BOSH_DEPLOYMENT}.yml"
 bosh deployment "${BOSH_DEPLOYMENT}.yml"
 
-echo
-echo "Use bosh-ssh to log in to a VM"
-echo
-
-exec bash
+exec bash --rcfile /bosh_wrapper.rc

--- a/bosh-shell/startup.sh
+++ b/bosh-shell/startup.sh
@@ -13,7 +13,7 @@ ssh -fNT -4 -L 25555:localhost:25555 \
   -o ExitOnForwardFailure=yes \
   -o StrictHostKeyChecking=no \
   -o UserKnownHostsFile=/dev/null \
-  -o ServerAliveInterval=60 \
+  -o ServerAliveInterval=30 \
   "vcap@$BOSH_IP" -i /tmp/bosh_id_rsa
 
 bosh -t localhost login admin -- "$BOSH_ADMIN_PASSWORD"

--- a/bosh-shell/startup.sh
+++ b/bosh-shell/startup.sh
@@ -19,6 +19,9 @@ ssh -fNT -4 -L 25555:localhost:25555 \
 bosh -t localhost login admin -- "$BOSH_ADMIN_PASSWORD"
 bosh target localhost
 
+bosh download manifest "${BOSH_DEPLOYMENT}" "${BOSH_DEPLOYMENT}.yml"
+bosh deployment "${BOSH_DEPLOYMENT}.yml"
+
 echo
 echo "Use bosh-ssh to log in to a VM"
 echo


### PR DESCRIPTION
## What

### bosh-shell: Automatically target BOSH deployment

So that you don't have to run these commands yourself each time you use
`make bosh-cli` from paas-bootstrap, which I find very frustrating. The old
target in paas-cf used to do an equivalent of this for you.

This requires a new environment variable to be passed from paas-bootstrap.
I've called it something other than `DEPLOY_ENV` to make it easier to
understand what it is used for.

### bosh-shell: Use a wrapper script for bosh ssh

Rather than requiring people to run a separate command because I keep
forgetting this. This works because `exec bosh` within the script doesn't
use the `alias` set in the shell.

The existing `bosh --version` spec test should make sure that normal bosh
usage still works. I don't think we can do much more without a director.

## How to review

See alphagov/paas-bootstrap#118

## Who can review

Anyone, but possibly @alext while on support.