### PR TITLE
Upgrade psql Docker image to latest Alpine version

### DIFF
--- a/psql/Dockerfile
+++ b/psql/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.3
+FROM alpine:3.7
 
 ENV PACKAGES "postgresql-client"
 

--- a/psql/psql_spec.rb
+++ b/psql/psql_spec.rb
@@ -10,7 +10,7 @@ describe "psql image" do
   }
 
   it "installs the right version of Alpine" do
-    expect(os_version).to include("Alpine Linux 3.3")
+    expect(os_version).to include("Alpine Linux 3.7")
   end
 
   def os_version


### PR DESCRIPTION
Newer versions of Alpine (>=3.4) support search domains in `resolv.conf`. Without this it is tricky to run this image within k8s.

This fixes tests from PR #110.