### PR TITLE
bosh-shell: handle non-existing CF deployment

### DIFF
--- a/bosh-shell/startup.sh
+++ b/bosh-shell/startup.sh
@@ -19,7 +19,11 @@ ssh -fNT -4 -L 25555:localhost:25555 \
 bosh -t localhost login admin -- "$BOSH_ADMIN_PASSWORD"
 bosh target localhost
 
-bosh download manifest "${BOSH_DEPLOYMENT}" "${BOSH_DEPLOYMENT}.yml"
-bosh deployment "${BOSH_DEPLOYMENT}.yml"
+if bosh download manifest "${BOSH_DEPLOYMENT}" "${BOSH_DEPLOYMENT}.yml"; then
+  bosh deployment "${BOSH_DEPLOYMENT}.yml"
+else
+  echo "No deployment targetted..."
+  echo "You'll need to manually download a manifest and target a deployment."
+fi
 
 exec bash --rcfile /bosh_wrapper.rc


### PR DESCRIPTION
## What

Currently the startup script attempts to download the bosh manifest for
the corresponding CF deployment and target it. If this deployment
doesn't exist, it causes the download to fail, and the startup script to
abort. As a result it's not possible to use this when the CF deployment
doesn't exist.

This updates the script to gracefully handle a missing CF deployment so
that you can still interact with bosh.

## How to review

Review along with paas-bootstrap PR TBC

## Who can review

Not me.