### PR TITLE
[#154437339] Update bosh-init to cache bosh-aws-cpi v69

### DIFF
--- a/bosh-init/Dockerfile
+++ b/bosh-init/Dockerfile
@@ -13,8 +13,8 @@ RUN apt-get install -y wget
 RUN wget -q -O /usr/local/bin/bosh-init --no-check-certificate ${BOSH_INIT_URL}
 RUN chmod +x /usr/local/bin/bosh-init
 
-ENV BOSH_AWS_CPI_URL https://bosh.io/d/github.com/cloudfoundry-incubator/bosh-aws-cpi-release?v=62
-ENV BOSH_AWS_CPI_CHECKSUM f36967927ceae09e5663a41fdda199edfe649dc6
+ENV BOSH_AWS_CPI_URL https://bosh.io/d/github.com/cloudfoundry-incubator/bosh-aws-cpi-release?v=69
+ENV BOSH_AWS_CPI_CHECKSUM 8abe70219244896ea6f7208fc01f2eac56179170
 
 COPY bosh_init_cache /tmp/bosh_init_cache/
 RUN /tmp/bosh_init_cache/seed_bosh_init_cache.sh && \


### PR DESCRIPTION
[#154437339 Upgrade BOSH director and AWS CPI](https://www.pivotaltracker.com/story/show/154437339)

What?
-----

We want to upgrade our bosh-aws-cpi to use the latest version v69.[1][2]

We update the governmentpaas/bosh-init container to include the
cache of this new version, so bosh-init won't need to build and
compile it every time.

How to review?
--------------

 * Code review
 * `rake build:bosh-init spec:bosh-init `

Who?
---

Anyone but @keymon or @henryk

[1] https://github.com/cloudfoundry-incubator/bosh-aws-cpi-release/releases/tag/v69
[2] https://bosh.io/releases/github.com/cloudfoundry-incubator/bosh-aws-cpi-release?version=69