### PR TITLE
[#154769249] cf-acceptance-tests: Upgrade cf-cli

### DIFF
--- a/cf-acceptance-tests/Dockerfile
+++ b/cf-acceptance-tests/Dockerfile
@@ -23,7 +23,7 @@ RUN go get github.com/tools/godep
 RUN go get github.com/onsi/ginkgo/ginkgo
 
 # Install the cf CLI
-RUN wget -q -O cf.deb "https://cli.run.pivotal.io/stable?release=debian64&version=6.32.0&source=github-rel" && \
+RUN wget -q -O cf.deb "https://cli.run.pivotal.io/stable?release=debian64&version=6.34.1&source=github-rel" && \
     dpkg -i cf.deb && \
     rm -f cf.deb
 

--- a/cf-acceptance-tests/cf-acceptance-tests_spec.rb
+++ b/cf-acceptance-tests/cf-acceptance-tests_spec.rb
@@ -3,7 +3,7 @@ require 'docker'
 require 'serverspec'
 
 GO_VERSION="1.9"
-CF_CLI_VERSION="6.32.0"
+CF_CLI_VERSION="6.34.1"
 
 describe "cf-acceptance-tests image" do
   before(:all) {


### PR DESCRIPTION
## What

Upgrade cf-cli to latest.

Using cloudfoundry/cf-acceptance-tests@cf1.14 for
cloudfoundry/cf-deployment@v1.14.0 has this failure with the previous
version of the container:

    CLI version 6.33.1 is required

    Expected
        <bool>: false
    to be true

## How to review

See alphagov/paas-cf#1229

## Who can review

Anyone.