### PR TITLE
[Firebreak] Add image for executing arbitrary Bosh commands

### DIFF
--- a/bosh-shell/README.md
+++ b/bosh-shell/README.md
@@ -11,17 +11,4 @@ $ docker build -t bosh-shell .
 
 ## Run
 
-The containers need to be run using the script in paas-bootstrap: `paas-bootstrap/scripts/bo.sh`. This is because the `ENTRYPOINT` of the container has a dependency on the Bosh IP and Bosh VM private SSH key. On startup, the container will locally forward the Bosh port (25555).
-
-## Bosh CLI
-
-Bosh CLI commands will work from the container. However, you will need to target the deployment first:
-
-```
-bosh download manifest "$DEPLOY_ENV" manifest.yml
-bosh deployment manifest.yml
-```
-
-## Bosh SSH
-
-A script called 'bosh-ssh' will be available on the `PATH` in the container. This is a simple wrapper for the `bosh ssh` command which adds the gateway details for you, as the Bosh VM will act as an SSH gateway to the Bosh-managed VMs. Run `bosh-ssh` in the container for usage details.
+The containers need to be run using the bosh-cli `make` target in paas-bootstrap. This is because the `ENTRYPOINT` of the container has a dependency on the Bosh IP and Bosh VM private SSH key. On startup, the container will locally forward the Bosh port (25555).

--- a/bosh/Dockerfile
+++ b/bosh/Dockerfile
@@ -1,0 +1,18 @@
+FROM ruby:2.2-alpine
+
+ENV BOSH_CLI_VERSION 3.0.1
+ENV BOSH_CLI_SUM ccc893bab8b219e9e4a628ed044ebca6c6de9ca0
+ENV BOSH_CLI_FILENAME bosh-cli-${BOSH_CLI_VERSION}-linux-amd64
+
+RUN apk add --update wget bash openssl openssh-client file git netcat-openbsd \
+   && rm -rf /var/cache/apk/*
+
+RUN wget -nv https://s3.amazonaws.com/bosh-cli-artifacts/${BOSH_CLI_FILENAME} \
+  && echo "${BOSH_CLI_SUM}  ${BOSH_CLI_FILENAME}" | sha1sum -c - \
+  && chmod +x ${BOSH_CLI_FILENAME} \
+  && mv ${BOSH_CLI_FILENAME} /usr/local/bin/bosh
+
+COPY startup.sh /startup.sh
+
+ENTRYPOINT ["/startup.sh"]
+CMD []

--- a/bosh/README.md
+++ b/bosh/README.md
@@ -1,0 +1,14 @@
+# Bosh Shell
+
+An image for executing arbitrary Bosh CLI commands.
+
+## Build locally
+
+```
+$ cd bosh
+$ docker build -t bosh .
+```
+
+## Run
+
+The containers need to be run using the script in the paas-infrastructure-map repository.

--- a/bosh/bosh_spec.rb
+++ b/bosh/bosh_spec.rb
@@ -1,0 +1,56 @@
+require 'spec_helper'
+require 'docker'
+require 'serverspec'
+
+BOSH_CLI_VERSION="3.0.1-712bfd7-2018-03-13T23:26:43Z"
+
+describe "bosh image" do
+  before(:all) {
+    set :docker_image, find_image_id('bosh:latest')
+  }
+
+  it "has the expected version of the Bosh CLI" do
+    expect(
+      command("bosh --version").stdout.strip
+    ).to eq("version #{BOSH_CLI_VERSION}")
+  end
+
+  it "has `file` available" do
+    expect(
+      command("file --version").exit_status
+    ).to eq(0)
+  end
+
+  it "has ssh available" do
+    expect(
+      command("ssh -V").exit_status
+    ).to eq(0)
+  end
+
+  it "can run git" do
+    expect(command('git --version').exit_status).to eq(0)
+  end
+
+  it "has `bash` available" do
+    expect(
+      command("bash --version").exit_status
+    ).to eq(0)
+  end
+
+  it "has a new enough version of openssl available" do
+    # wget (from busybox) requires openssl to be able to connect to https sites.
+
+    # See https://github.com/nahi/httpclient/blob/v2.7.1/lib/httpclient/ssl_config.rb#L441-L452
+    # (httpclient is a dependency of bosh_cli)
+    # With an older version of openssl, bosh_cli spits out warnings.
+    cmd = command("openssl version")
+    expect(cmd.exit_status).to eq(0)
+
+    ssl_version_str = cmd.stdout.strip
+    if ssl_version_str.start_with?('OpenSSL 1.0.1')
+      expect(ssl_version_str).to be >= 'OpenSSL 1.0.1p'
+    else
+      expect(ssl_version_str).to be >= 'OpenSSL 1.0.2d'
+    end
+  end
+end

--- a/bosh/hooks/README.md
+++ b/bosh/hooks/README.md
@@ -1,0 +1,9 @@
+# Hooks
+
+This directory should be symlinked into each container sub-directory in this
+repository. It contains [custom build phase hooks][hooks] that are used by
+automated builds on [Docker Hub][] and [Docker Cloud][].
+
+[hooks]: https://docs.docker.com/docker-cloud/builds/advanced/#custom-build-phase-hooks) 
+[Docker Hub]: https://hub.docker.com/
+[Docker Cloud]: https://cloud.docker.com/

--- a/bosh/hooks/post_push
+++ b/bosh/hooks/post_push
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -eu
+
+# Docker Hub doesn't have this (but Docker Cloud might).
+export SOURCE_COMMIT
+SOURCE_COMMIT="${SOURCE_COMMIT:-$(git rev-parse HEAD)}"
+
+# Create an immutable tag that we can reference for merge commits on master.
+if [ "${SOURCE_BRANCH}" = "master" ]; then
+  echo "Creating additional tag: ${SOURCE_COMMIT}"
+  docker tag "${IMAGE_NAME}" "${DOCKER_REPO}:${SOURCE_COMMIT}"
+  docker push "${DOCKER_REPO}:${SOURCE_COMMIT}"
+else
+  echo "Not creating tag for branch: ${SOURCE_BRANCH}"
+fi

--- a/bosh/startup.sh
+++ b/bosh/startup.sh
@@ -22,6 +22,4 @@ export BOSH_GW_HOST=$BOSH_IP
 export BOSH_GW_USER=vcap
 export BOSH_GW_PRIVATE_KEY=/tmp/bosh_id_rsa
 
-bosh login --client=admin --client-secret="$BOSH_ADMIN_PASSWORD"
-
 exec bosh "$@"

--- a/bosh/startup.sh
+++ b/bosh/startup.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+set -eu
+
+if [ -z "${BOSH_ID_RSA:-}" ] || [ -z "${BOSH_IP:-}" ] || [ -z "${BOSH_ENVIRONMENT:-}" ] || [ -z "${BOSH_CA_CERT:-}" ]; then
+  echo "WARNING: You need to set BOSH_ID_RSA, BOSH_IP, BOSH_ENVIRONMENT and BOSH_CA_CERT."
+  echo "You will not be logged into Bosh."
+  exec bash
+fi
+
+echo "$BOSH_ID_RSA" | base64 -d > /tmp/bosh_id_rsa && chmod 400 /tmp/bosh_id_rsa
+
+ssh -fNC -4 -D 25555 \
+  -o ExitOnForwardFailure=yes \
+  -o StrictHostKeyChecking=no \
+  -o UserKnownHostsFile=/dev/null \
+  -o ServerAliveInterval=30 \
+  "vcap@$BOSH_IP" -i /tmp/bosh_id_rsa
+
+export BOSH_ALL_PROXY="socks5://localhost:25555"
+export BOSH_GW_HOST=$BOSH_IP
+export BOSH_GW_USER=vcap
+export BOSH_GW_PRIVATE_KEY=/tmp/bosh_id_rsa
+
+bosh login --client=admin --client-secret="$BOSH_ADMIN_PASSWORD"
+
+exec bosh "$@"


### PR DESCRIPTION
This allows you to execute one-off commands using Bosh. The initial
motivation for this comes from the repository paas-infrastructure-map,
which provides the tools necessary to query Bosh and build a dynamic
map of a Bosh deployment.

We use the empty exec-style `CMD` declaration to override the command
of the base Ruby image.