### PR TITLE
[#156299675] Use cf-cli 6.36.0 for CATs tests

### DIFF
--- a/cf-acceptance-tests/Dockerfile
+++ b/cf-acceptance-tests/Dockerfile
@@ -23,7 +23,7 @@ RUN go get github.com/tools/godep
 RUN go get github.com/onsi/ginkgo/ginkgo
 
 # Install the cf CLI
-RUN wget -q -O cf.deb "https://cli.run.pivotal.io/stable?release=debian64&version=6.34.1&source=github-rel" && \
+RUN wget -q -O cf.deb "https://cli.run.pivotal.io/stable?release=debian64&version=6.36.0&source=github-rel" && \
     dpkg -i cf.deb && \
     rm -f cf.deb
 

--- a/cf-acceptance-tests/cf-acceptance-tests_spec.rb
+++ b/cf-acceptance-tests/cf-acceptance-tests_spec.rb
@@ -3,7 +3,7 @@ require 'docker'
 require 'serverspec'
 
 GO_VERSION="1.9"
-CF_CLI_VERSION="6.34.1"
+CF_CLI_VERSION="6.36.0"
 
 describe "cf-acceptance-tests image" do
   before(:all) {


### PR DESCRIPTION
https://www.pivotaltracker.com/n/projects/1275640/stories/156299675

What?
-----

The cf-acceptance-tests used by alphagov/paas-cf#1306 uses
a new command: `cf add-network-policy`, that was added in
cf 6.35.0, so the tests fail.

We upgrade to the latest cf-cli version.

How to review
------------

Review with alphagov/paas-cf#1306

who?
----

Anyone but @keymon