### PR TITLE
[#155037639] Add spruce to cf-cli for manifest templating

### DIFF
--- a/cf-cli/Dockerfile
+++ b/cf-cli/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.3
 
-ENV PACKAGES "unzip curl openssl ca-certificates git ruby ruby-json libc6-compat"
+ENV PACKAGES "unzip curl openssl ca-certificates git ruby ruby-json libc6-compat bash"
 ENV CF_CLI_VERSION "6.34.1"
 ENV CF_BGD_VERSION "1.3.0"
 ENV CF_BGD_CHECKSUM "c74995ae0ba3ec9eded9c2a555e5984ba536d314cf9dc30013c872eb6b9d76b6"

--- a/cf-cli/Dockerfile
+++ b/cf-cli/Dockerfile
@@ -8,6 +8,7 @@ ENV CF_BGD_TEMPFILE "/tmp/blue-green-deploy.linux64"
 ENV CF_AUTOPILOT_VERSION "0.0.4"
 ENV CF_AUTOPILOT_CHECKSUM "a755f9da3981fb6dc6aa675a55f8fc7de9d73c87b8cad4883d98c543a45a9922"
 ENV CF_AUTOPILOT_TEMPFILE "/tmp/autopilot-linux"
+ENV SPRUCE_VERSION "1.17.0"
 
 RUN apk add --update $PACKAGES && rm -rf /var/cache/apk/*
 RUN ln -s /lib/ /lib64 # FIXME: Remove for Alpine >= 3.6
@@ -28,3 +29,6 @@ RUN curl -L -o "${CF_AUTOPILOT_TEMPFILE}" \
   && chmod +x "${CF_AUTOPILOT_TEMPFILE}" \
   && cf install-plugin -f "${CF_AUTOPILOT_TEMPFILE}" \
   && rm "${CF_AUTOPILOT_TEMPFILE}"
+
+RUN curl -Lo /usr/local/bin/spruce https://github.com/geofffranks/spruce/releases/download/v${SPRUCE_VERSION}/spruce-linux-amd64 \
+  && chmod +x /usr/local/bin/spruce

--- a/cf-cli/cf-acceptance-tests_spec.rb
+++ b/cf-cli/cf-acceptance-tests_spec.rb
@@ -79,4 +79,10 @@ describe "cf-cli image" do
     spruce_version = command("spruce --version").stdout.strip
     expect(spruce_version).to match(/spruce - Version #{SPRUCE_VERSION}( \(master\))?/)
   end
+
+  it "has `bash` available" do
+    expect(
+      command("bash --version").exit_status
+    ).to eq(0)
+  end
 end

--- a/cf-cli/cf-acceptance-tests_spec.rb
+++ b/cf-cli/cf-acceptance-tests_spec.rb
@@ -3,6 +3,8 @@ require 'docker'
 require 'serverspec'
 
 CF_CLI_VERSION="6.34.1"
+SPRUCE_BIN = "/usr/local/bin/spruce"
+SPRUCE_VERSION = "1.17.0"
 
 describe "cf-cli image" do
   before(:all) {
@@ -58,5 +60,23 @@ describe "cf-cli image" do
   it "has ruby json gem available" do
     cmd = command("ruby -e 'require \"json\"'")
     expect(cmd.exit_status).to eq(0)
+  end
+
+  it "has ruby yaml gem available" do
+    cmd = command("ruby -e 'require \"yaml\"'")
+    expect(cmd.exit_status).to eq(0)
+  end
+
+  it "checks if spruce binary exists and is a file" do
+    expect(file(SPRUCE_BIN)).to be_file
+  end
+
+  it "checks if spruce binary is executable" do
+    expect(file(SPRUCE_BIN)).to be_mode 755
+  end
+
+  it "has the spruce version #{SPRUCE_VERSION}" do
+    spruce_version = command("spruce --version").stdout.strip
+    expect(spruce_version).to match(/spruce - Version #{SPRUCE_VERSION}( \(master\))?/)
   end
 end


### PR DESCRIPTION
What?
----

I want to generate the manifest of the product page, pulling  secrets from .yml files in S3 buckets as we still don't have any sensible proper solution for this.

spruce[1] is a nice tool to kickly generate manifests, pull secrets from other variables, etc. It is handy to have it in the cf-cli container to simplify our pipelines, so that we can build a manifest and add the required config (env vars, secrets, routes, etc) seamlessly.

We also want to add bash, as it has more capabilities than the simple `sh`, we can write simpler scripts. The additional consume sized is minimal.

[1] https://github.com/geofffranks/spruce

How to review?
--------------

Code review

Who?
---

Anyone but me