### PR TITLE
[#157083954] Add the log-cache plugin to the cf-acceptance-tests container

### DIFF
--- a/cf-acceptance-tests/Dockerfile
+++ b/cf-acceptance-tests/Dockerfile
@@ -11,9 +11,9 @@ RUN \
     git \
   && rm -rf /var/lib/apt/lists/*
 
- ENV GOPATH /go
- ENV PATH /go/bin:/usr/local/go/bin:$PATH
- RUN \
+ENV GOPATH /go
+ENV PATH /go/bin:/usr/local/go/bin:$PATH
+RUN \
   wget https://storage.googleapis.com/golang/go1.9.linux-amd64.tar.gz -P /tmp && \
   tar xzvf /tmp/go1.9.linux-amd64.tar.gz -C /usr/local && \
   mkdir $GOPATH && \
@@ -27,8 +27,11 @@ RUN wget -q -O cf.deb "https://cli.run.pivotal.io/stable?release=debian64&versio
     dpkg -i cf.deb && \
     rm -f cf.deb
 
+# Setup plugins
+ENV CF_PLUGIN_HOME /root/
+
 # Install the container networking CLI plugin
-RUN wget -q -O /tmp/network-policy-plugin "https://github.com/cloudfoundry-incubator/netman-release/releases/download/v0.11.0/network-policy-plugin-linux64" && \
-  chmod +x /tmp/network-policy-plugin && \
-  cf install-plugin /tmp/network-policy-plugin -f && \
-  rm -rf /tmp/*
+RUN cf install-plugin -f "https://github.com/cloudfoundry-incubator/netman-release/releases/download/v0.11.0/network-policy-plugin-linux64"
+
+# Install the log-cache-cli plugin
+RUN cf install-plugin -f https://github.com/cloudfoundry/log-cache-cli/releases/download/v1.1.0/log-cache-cf-plugin-linux

--- a/cf-acceptance-tests/cf-acceptance-tests_spec.rb
+++ b/cf-acceptance-tests/cf-acceptance-tests_spec.rb
@@ -4,6 +4,7 @@ require 'serverspec'
 
 GO_VERSION="1.9"
 CF_CLI_VERSION="6.36.0"
+LOG_CACHE_CLI_VERSION="1.1.0"
 
 describe "cf-acceptance-tests image" do
   before(:all) {
@@ -48,5 +49,28 @@ describe "cf-acceptance-tests image" do
     expect(
       command("unzip -v").exit_status
     ).to eq(0)
+  end
+
+  it "has the CF_PLUGIN_HOME variable set" do
+    expect(
+      command("env").stdout
+    ).to match(/^CF_PLUGIN_HOME=\/root/)
+  end
+
+  it "has the network-policy plugin" do
+    # Needed by the cf acceptance-test suite network polices
+    plugins_output = command("cf plugins").stdout
+
+    expect(plugins_output).to match(/^network-policy +[^ ]+ +allow-access /)
+    expect(plugins_output).to match(/^network-policy +[^ ]+ +deny-access /)
+    expect(plugins_output).to match(/^network-policy +[^ ]+ +list-access /)
+    expect(plugins_output).to match(/^network-policy +[^ ]+ +remove-access /)
+  end
+
+  it "has the log-cache plugin" do
+    # Needed by the cf acceptance-test with log-cache mode
+    plugins_output = command("cf plugins").stdout
+    expect(plugins_output).to match(/^log-cache +#{LOG_CACHE_CLI_VERSION} +log-meta/)
+    expect(plugins_output).to match(/^log-cache +#{LOG_CACHE_CLI_VERSION} +tail /)
   end
 end


### PR DESCRIPTION

https://www.pivotaltracker.com/story/show/157083954

What?
-----

We want to test the log-cache service using the cf-acceptance-tests[1], but
for that we need the corresponding plugin installed in the container.

Additionally, as the tests would change the CF_HOME variable, we must
set the CF_PLUGIN_HOME at the container level so the containers
are available when the tests run.

How to review?
------

Review as part of https://github.com/alphagov/paas-cf/pull/1371

Dependencies
----------

Update https://github.com/alphagov/paas-cf/pull/1371 once this is merged
and the new container generated

Who?
----

Anyone but me or @paroxp

[1] https://github.com/cloudfoundry/cf-acceptance-tests/commit/923a0fe9335bf0a1e75286801e952f248491cd38

