### PR TITLE
Add the MIT licence to the repo

### DIFF
--- a/LICENCE.md
+++ b/LICENCE.md
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018 Crown Copyright (Government Digital Service)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## What 

We had an [issue raised](https://github.com/alphagov/paas-docker-cloudfoundry-tools/issues/127) regarding the license type we used. This PR clarifies this.

## How to review

Confirm that the added license conforms to the [GDS way](https://gds-way.cloudapps.digital/manuals/licensing.html#each-repository-should-include-a-licence-file)

## Who can merge

Not @LeePorte