### PR TITLE
[#140398377] Upgrade Terraform AWS provider

### DIFF
--- a/terraform/plugin_cache.tf
+++ b/terraform/plugin_cache.tf
@@ -1,5 +1,5 @@
 provider "aws" {
-  version = "1.6.0"
+  version = "1.8.0"
 }
 provider "datadog" {
   version = "1.0.3"


### PR DESCRIPTION
## What

This is the minimum upgrade required to fix an issue we are having with
DNS entries flapping[1].

[1] https://github.com/terraform-providers/terraform-provider-aws/issues/361

## How to review

The short version: just code review, sanity check, and merge. This is because we pin versions of this image where it is consumed (paas-bootstrap and paas-cf), so it can be tested properly in those repositories.

Knowing this will work properly is tricky because our dev environments are not affected by this issue (https://github.com/terraform-providers/terraform-provider-aws/issues/361). They are not affected because they do not have the old versions of ELBs that cause the problems, whereas our persistent environments are running with old ELB versions, which are non-trivial to replace.

In theory, you could push an amended version of the staging deployer Concourse pipeline to pin this dev version, then verify by triggering the cf-terraform job and making sure it doesn't recreate the `aws_route53_record.apps_apex` resource. However, manual fiddling with persistent environments is bad practice. Your call.

To save you time I have run the bootstrap creation and deletion and paas-cf creation and deletion to ensure it at least doesn't break anything.

## Who

Anyone but me