### PR TITLE
[#160614327] Update bosh-cli-v2 to 5.2.1 with SKI for certs

### DIFF
--- a/bosh-cli-v2/Dockerfile
+++ b/bosh-cli-v2/Dockerfile
@@ -1,7 +1,7 @@
 FROM ruby:2.5-slim
 
-ENV BOSH_CLI_VERSION 3.0.1-gds1
-ENV BOSH_CLI_SUM fb71095c50aaf60865a4687cf22f2c826f44ed2f
+ENV BOSH_CLI_VERSION 3.0.1
+ENV BOSH_CLI_SUM ccc893bab8b219e9e4a628ed044ebca6c6de9ca0
 ENV BOSH_CLI_FILENAME bosh-cli-${BOSH_CLI_VERSION}-linux-amd64
 
 ENV DEBIAN_PACKAGES "ca-certificates wget git openssh-client file"
@@ -19,7 +19,7 @@ RUN apt-get update \
   && apt-get install -y --no-install-recommends ${BOSH_ENV_DEPS} \
   && rm -rf /var/lib/apt/lists/*
 
-RUN wget -nv https://github.com/alphagov/paas-bosh-cli/releases/download/v${BOSH_CLI_VERSION}/${BOSH_CLI_FILENAME} \
+RUN wget -nv https://s3.amazonaws.com/bosh-cli-artifacts/${BOSH_CLI_FILENAME} \
   && echo "${BOSH_CLI_SUM}  ${BOSH_CLI_FILENAME}" | sha1sum -c - \
   && chmod +x ${BOSH_CLI_FILENAME} \
   && mv ${BOSH_CLI_FILENAME} /usr/local/bin/bosh

--- a/bosh-cli-v2/Dockerfile
+++ b/bosh-cli-v2/Dockerfile
@@ -1,7 +1,7 @@
 FROM ruby:2.5-slim
 
-ENV BOSH_CLI_VERSION 3.0.1
-ENV BOSH_CLI_SUM ccc893bab8b219e9e4a628ed044ebca6c6de9ca0
+ENV BOSH_CLI_VERSION 5.2.1
+ENV BOSH_CLI_SUM 89916f4b499f46037e7217ffceda0f1a352006b8
 ENV BOSH_CLI_FILENAME bosh-cli-${BOSH_CLI_VERSION}-linux-amd64
 
 ENV DEBIAN_PACKAGES "ca-certificates wget git openssh-client file"

--- a/bosh-cli-v2/bosh-cli_spec.rb
+++ b/bosh-cli-v2/bosh-cli_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'docker'
 require 'serverspec'
 
-BOSH_CLI_VERSION="3.0.1-712bfd7-2018-03-13T23:26:43Z"
+BOSH_CLI_VERSION="5.2.1-24101936-2018-08-27T21:55:34Z"
 
 BOSH_ENV_DEPS = "build-essential zlibc zlib1g-dev openssl libxslt1-dev libxml2-dev \
     libssl-dev libreadline7 libreadline-dev libyaml-dev libsqlite3-dev sqlite3"

--- a/bosh-cli-v2/bosh-cli_spec.rb
+++ b/bosh-cli-v2/bosh-cli_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'docker'
 require 'serverspec'
 
-BOSH_CLI_VERSION="3.0.1-gds1-f66c0b4-2018-06-07T15:18:52Z"
+BOSH_CLI_VERSION="3.0.1-712bfd7-2018-03-13T23:26:43Z"
 
 BOSH_ENV_DEPS = "build-essential zlibc zlib1g-dev openssl libxslt1-dev libxml2-dev \
     libssl-dev libreadline7 libreadline-dev libyaml-dev libsqlite3-dev sqlite3"


### PR DESCRIPTION
What?
-----

The version 5.2.1 [1] supports generating certificates via `--vars-store` with SKI/AKI.

We need this to be able to rotate CA certificates used by CF API, otherwise
it is not possible to use two CA certs with the same name at the same time.

More info in [2]

[1] https://github.com/cloudfoundry/bosh-cli/releases/tag/v5.2.1
[2] https://github.com/cloudfoundry/config-server/pull/9

The upstream project for bosh-cli now

How to review
-------------

Check that the new container generate certs with the SKI. You can do so
with this script:

```
test_bosh_cli_cert() {
    image=$1
    manifest='
cert: ((test.certificate))

variables:
- name: test
  options:
    common_name: foo
    is_ca: true
  type: certificate
'
    echo "${manifest}" | \
        docker run -i ${image} bosh interpolate - --vars-store=/ignore.yml | \
        ruby -ryaml -e 'puts YAML.load(STDIN)["cert"] ' | \
        openssl x509 -text -noout -in - | \
        grep -A 4 "Subject Key Identifier"

}

test_bosh_cli_cert governmentpaas/bosh-cli-v2:latest

test_bosh_cli_cert governmentpaas/bosh-cli-v2:update_bosh_cli-160614327

```

What next?
---------

Once merged, a new container id would be gerated and paas-cf needs updating.

Who?
----

Not me