### PR TITLE
[#160614327] Update bosh-cli for bosh and bosh-shell

### DIFF
--- a/bosh-shell/Dockerfile
+++ b/bosh-shell/Dockerfile
@@ -1,7 +1,7 @@
 FROM ruby:2.5-alpine
 
-ENV BOSH_CLI_VERSION 2.0.48
-ENV BOSH_CLI_SUM c807f1938494f4280d65ebbdc863eda3f883d72e
+ENV BOSH_CLI_VERSION 5.2.1
+ENV BOSH_CLI_SUM 89916f4b499f46037e7217ffceda0f1a352006b8
 ENV BOSH_CLI_FILENAME bosh-cli-${BOSH_CLI_VERSION}-linux-amd64
 
 RUN apk add --update wget bash openssl openssh-client file git netcat-openbsd \

--- a/bosh-shell/bosh-shell_spec.rb
+++ b/bosh-shell/bosh-shell_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'docker'
 require 'serverspec'
 
-BOSH_CLI_VERSION="2.0.48-e94aeeb-2018-01-09T23:08:07Z"
+BOSH_CLI_VERSION="5.2.1-24101936-2018-08-27T21:55:34Z"
 
 describe "bosh-shell image" do
   before(:all) {

--- a/bosh/Dockerfile
+++ b/bosh/Dockerfile
@@ -1,7 +1,7 @@
 FROM ruby:2.5-alpine
 
-ENV BOSH_CLI_VERSION 3.0.1
-ENV BOSH_CLI_SUM ccc893bab8b219e9e4a628ed044ebca6c6de9ca0
+ENV BOSH_CLI_VERSION 5.2.1
+ENV BOSH_CLI_SUM 89916f4b499f46037e7217ffceda0f1a352006b8
 ENV BOSH_CLI_FILENAME bosh-cli-${BOSH_CLI_VERSION}-linux-amd64
 
 RUN apk add --update wget bash openssl openssh-client file git netcat-openbsd \

--- a/bosh/bosh_spec.rb
+++ b/bosh/bosh_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'docker'
 require 'serverspec'
 
-BOSH_CLI_VERSION="3.0.1-712bfd7-2018-03-13T23:26:43Z"
+BOSH_CLI_VERSION="5.2.1-24101936-2018-08-27T21:55:34Z"
 
 describe "bosh image" do
   before(:all) {


### PR DESCRIPTION
What?
----

We have update the bosh-cli-v2 to use bosh-cli 5.2.1 with SKI for
certs, and we want to use the same in the rest of containers
for consistency.

The version 5.2.1 [1] supports generating certificates via
--vars-store with SKI/AKI.

We need this to be able to rotate CA certificates used by CF API,
otherwise it is not possible to use two CA certs with the same name
at the same time.

More info in [2]

[1] https://github.com/cloudfoundry/bosh-cli/releases/tag/v5.2.1
[2] https://github.com/cloudfoundry/config-server/pull/9

How to review?
-----

code review, tests pass

Who?
----

not me