### PR TITLE
Include gettext's `envsubst` in the cf-cli image

### DIFF
--- a/cf-cli/Dockerfile
+++ b/cf-cli/Dockerfile
@@ -1,6 +1,6 @@
 FROM ruby:2.6-alpine3.9
 
-ENV PACKAGES "unzip curl openssl ca-certificates git libc6-compat bash jq"
+ENV PACKAGES "unzip curl openssl ca-certificates git libc6-compat bash jq gettext"
 ENV CF_CLI_VERSION "6.45.0"
 ENV CF_BGD_VERSION "1.3.0"
 ENV CF_BGD_CHECKSUM "c74995ae0ba3ec9eded9c2a555e5984ba536d314cf9dc30013c872eb6b9d76b6"

--- a/cf-cli/cf-cli_spec.rb
+++ b/cf-cli/cf-cli_spec.rb
@@ -84,4 +84,10 @@ describe "cf-cli image" do
       command("bash --version").exit_status
     ).to eq(0)
   end
+
+  it "has `envsubst` available" do
+    expect(
+      command("envsubst --help").exit_status
+    ).to eq(0)
+  end
 end


### PR DESCRIPTION
`Envsubst` implements *just* enough of a basic templating system to
allow CF manifests to use envvars easily. This allows inline/pipeline
verbosity such as this:

```bash
$ ruby -ryaml -e "
  env = {
    'LOG_CACHE_API' => 'https://log-cache.${SYSTEM_DNS_ZONE_NAME}',
  }
  manifest = YAML.load_file('manifest.yml')
  manifest['applications'].each { |app|
    app['env'] = {} unless app['env']
    app['env'].merge!(env)
    app['routes'] = [
      { 'route' => 'metrics.${SYSTEM_DNS_ZONE_NAME}' }
    ]
  }
  File.write('manifest.yml', manifest.to_yaml)
"
$ cf zero-downtime-push paas-log-cache-adapter -f manifest.yml
```

... to be replaced with this:

```bash
$ cf zero-downtime-push paas-log-cache-adapter -f <(envsubst '$SYSTEM_DNS_ZONE_NAME' <manifest.yml)
```

Adding this package doesn't mandate its use, of course; it merely
enables it.