### PR TITLE
[#161388997] Don't pass command line parameters to `bosh login`

### DIFF
--- a/bosh-shell/startup.sh
+++ b/bosh-shell/startup.sh
@@ -22,6 +22,6 @@ export BOSH_GW_HOST=$BOSH_IP
 export BOSH_GW_USER=vcap
 export BOSH_GW_PRIVATE_KEY=/tmp/bosh_id_rsa
 
-bosh login --client=admin --client-secret="$BOSH_ADMIN_PASSWORD"
+bosh login
 
 exec bash


### PR DESCRIPTION
## What

Bosh is becoming more dependent on using UAA to authenticate, so we are
going to start using UAA. This means on every operation you have to pass
these flags, otherwise it can use the wrong OAuth flow. For example, the
initial `bosh login` may work, but a subsequent `bosh vms` operation
will result in authorization failure.

The correct usage of the Bosh CLI now is to use the environment
variables `BOSH_CLIENT` and `BOSH_CLIENT_SECRET`, which ensures the
correct authentication flow on every operation. We can pass said
variables when invoking this image, so don't need to reference them in
this script.

## How to review

Review with the pull request on paas-bootstrap

## Who

Anyone but me or @keymon 