### PR TITLE
[#161388997] No longer do `bosh login` in bosh-shell entrypoint

### DIFF
--- a/bosh-shell/startup.sh
+++ b/bosh-shell/startup.sh
@@ -22,6 +22,4 @@ export BOSH_GW_HOST=$BOSH_IP
 export BOSH_GW_USER=vcap
 export BOSH_GW_PRIVATE_KEY=/tmp/bosh_id_rsa
 
-bosh login
-
 exec bash


### PR DESCRIPTION
## What

Now we are passing the environment variables `BOSH_CLIENT` and
`BOSH_CLIENT_SECRET` we do not need to perform a login. The Bosh CLI
will negotiate authentication on every operation anyway. Removing this
has the added benefit of not failing the startup script if login fails,
which means you can inspect the contents of the container more easily.

## How to revew

This will be merged by me or @keymon as part of https://github.com/alphagov/paas-bootstrap/pull/204