### PR TITLE
[#161544435] Update bosh cpi and base stemcell

### DIFF
--- a/bosh-cli-v2/Dockerfile
+++ b/bosh-cli-v2/Dockerfile
@@ -10,8 +10,8 @@ ENV DEBIAN_PACKAGES "ca-certificates wget git openssh-client file"
 ENV BOSH_ENV_DEPS "build-essential zlibc zlib1g-dev openssl libxslt1-dev \
   libxml2-dev libssl-dev libreadline7 libreadline-dev libyaml-dev libsqlite3-dev sqlite3"
 
-ENV BOSH_AWS_CPI_URL https://bosh.io/d/github.com/cloudfoundry-incubator/bosh-aws-cpi-release?v=69
-ENV BOSH_AWS_CPI_CHECKSUM 8abe70219244896ea6f7208fc01f2eac56179170
+ENV BOSH_AWS_CPI_URL https://bosh.io/d/github.com/cloudfoundry-incubator/bosh-aws-cpi-release?v=73
+ENV BOSH_AWS_CPI_CHECKSUM 350aa469deb281911b64d0be99faacfd26acdfaf
 
 RUN apt-get update \
   && apt-get -y upgrade \

--- a/bosh-cli-v2/bosh_init_cache/minimal_in.yml
+++ b/bosh-cli-v2/bosh_init_cache/minimal_in.yml
@@ -15,8 +15,8 @@ resource_pools:
 - name: dummy
   network: dummy
   stemcell:
-    sha1: 1a29c43d4e8abf7476ed6bb83168df1bdb742022
-    url: https://bosh.io/d/stemcells/bosh-aws-xen-hvm-ubuntu-trusty-go_agent?v=3074
+    sha1: c8b65794ca4c45773b6fe23b3d447dde520f07b0
+    url: https://bosh.io/d/stemcells/bosh-aws-xen-hvm-ubuntu-xenial-go_agent?v=170.3
 jobs:
 - name: dummy
   networks:


### PR DESCRIPTION
What?
----

In the container bosh-cli-v2 we precompile the bosh-cpi release
to speed up the deployments.

In this commit we update the version of the bosh-cpi and the
related stemcell to put it in sync with the new version in
paas-bootstrap[1]

[1]  https://github.com/alphagov/paas-bootstrap/pull/210

How to review
------------

Code review.

Merge, build the container and adapt references in paas-bootstrap and
paas-cf pipeline

Who?
---

Not me