### PR TITLE
Added AWS-CLI to cf-acceptance tests container.

### DIFF
--- a/cf-acceptance-tests/Dockerfile
+++ b/cf-acceptance-tests/Dockerfile
@@ -9,6 +9,7 @@ RUN \
     openssh-client \
     unzip \
     git \
+    python-pip \
   && rm -rf /var/lib/apt/lists/*
 
 ENV GOPATH /go
@@ -32,3 +33,6 @@ ENV CF_PLUGIN_HOME /root/
 
 # Install the log-cache-cli plugin
 RUN cf install-plugin -f https://github.com/cloudfoundry/log-cache-cli/releases/download/v2.0.0/log-cache-cf-plugin-linux
+
+# Install the AWS-CLI
+RUN pip install awscli=="1.14.10"

--- a/cf-acceptance-tests/cf-acceptance-tests_spec.rb
+++ b/cf-acceptance-tests/cf-acceptance-tests_spec.rb
@@ -63,4 +63,11 @@ describe "cf-acceptance-tests image" do
     expect(plugins_output).to match(/^log-cache +#{LOG_CACHE_CLI_VERSION} +log-meta/)
     expect(plugins_output).to match(/^log-cache +#{LOG_CACHE_CLI_VERSION} +tail /)
   end
+
+  it "has AWS CLI available" do
+    expect(
+      command("aws --version").exit_status
+    ).to eq(0)
+  end
+
 end


### PR DESCRIPTION
What
----

This PR adds the AWS CLI to the cf acceptance tests docker image in
order for us to be able to replicate current smoke test failure sending
an alert email for each test fail, and firing a pagerduty alert on 3
consecutive failures.

How to review
----

code review and tests passing

Who can review?
----

Not @leePorte