### PR TITLE
[#161544435] Upgrade cf-log-cache plugin and cf-cli

### DIFF
--- a/cf-acceptance-tests/Dockerfile
+++ b/cf-acceptance-tests/Dockerfile
@@ -31,4 +31,4 @@ RUN wget -q -O cf.deb "https://cli.run.pivotal.io/stable?release=debian64&versio
 ENV CF_PLUGIN_HOME /root/
 
 # Install the log-cache-cli plugin
-RUN cf install-plugin -f https://github.com/cloudfoundry/log-cache-cli/releases/download/v1.1.0/log-cache-cf-plugin-linux
+RUN cf install-plugin -f https://github.com/cloudfoundry/log-cache-cli/releases/download/v2.0.0/log-cache-cf-plugin-linux

--- a/cf-acceptance-tests/cf-acceptance-tests_spec.rb
+++ b/cf-acceptance-tests/cf-acceptance-tests_spec.rb
@@ -4,7 +4,7 @@ require 'serverspec'
 
 GO_VERSION="1.9"
 CF_CLI_VERSION="6.39.1"
-LOG_CACHE_CLI_VERSION="1.1.0"
+LOG_CACHE_CLI_VERSION="2.0.0"
 
 describe "cf-acceptance-tests image" do
   before(:all) {


### PR DESCRIPTION
What?
----

During the upgrade of cf-deployment to v6.0.0[1] log-cache has been
upgraded. The new version of log-cache uses a new protocol
and it is not compatible with old clients.

We need to update the log-cache cf client plugin that runs on the
tests.

[1] https://github.com/cloudfoundry/cf-deployment/releases/tag/v6.0.0

How to review
-----------

Code review. Travis should pass

Who?
----

Not me