### PR TITLE
[#161544435] Downgrade bosh-cli-v2 bundled bosh-cpi to v72

### DIFF
--- a/bosh-cli-v2/Dockerfile
+++ b/bosh-cli-v2/Dockerfile
@@ -10,8 +10,8 @@ ENV DEBIAN_PACKAGES "ca-certificates wget git openssh-client file"
 ENV BOSH_ENV_DEPS "build-essential zlibc zlib1g-dev openssl libxslt1-dev \
   libxml2-dev libssl-dev libreadline7 libreadline-dev libyaml-dev libsqlite3-dev sqlite3"
 
-ENV BOSH_AWS_CPI_URL https://bosh.io/d/github.com/cloudfoundry-incubator/bosh-aws-cpi-release?v=73
-ENV BOSH_AWS_CPI_CHECKSUM 350aa469deb281911b64d0be99faacfd26acdfaf
+ENV BOSH_AWS_CPI_URL https://bosh.io/d/github.com/cloudfoundry-incubator/bosh-aws-cpi-release?v=72
+ENV BOSH_AWS_CPI_CHECKSUM b7999e95115bb691a630c07f0439ef5b577884c2
 
 RUN apt-get update \
   && apt-get -y upgrade \


### PR DESCRIPTION
What?
----

Follow up of https://github.com/alphagov/paas-docker-cloudfoundry-tools/pull/140

v73 is too new, it has not release notes, and it seems to be
a major refactoring to introduce v2 api[1][2]

One team member had some issues with it already.

We downgrade to v72 to be on the safe side.

[1] https://github.com/cloudfoundry/bosh-aws-cpi-release/releases/tag/v73
[2] https://github.com/cloudfoundry/bosh-aws-cpi-release/compare/v72...v73


How to review
------------

code review, test should pass

Who?
----

Not me