### PR TITLE
[#161184357] Upgrade AWS terraform provider to 1.46.0

### DIFF
--- a/terraform/plugin_cache.tf
+++ b/terraform/plugin_cache.tf
@@ -1,5 +1,5 @@
 provider "aws" {
-  version = "1.6.0"
+  version = "1.46.0"
 }
 provider "datadog" {
   version = "1.0.3"


### PR DESCRIPTION
## What

The current version doesn't support the new ACM resources[1] which we need to manage our ACM certs using Terraform instead of the existing scripts.

[1]https://www.terraform.io/docs/providers/aws/r/acm_certificate_validation.html

## How to review

Review along with https://github.com/alphagov/paas-cf/pull/1646 and https://github.com/alphagov/paas-bootstrap/pull/220

## Who can review

Not me.