### PR TITLE
Include `gettext` in curl-ssl image

### DIFF
--- a/curl-ssl/Dockerfile
+++ b/curl-ssl/Dockerfile
@@ -1,7 +1,5 @@
 FROM alpine:3.3
 
-ENV PACKAGES "curl openssl ca-certificates"
+ENV PACKAGES "gettext curl openssl ca-certificates"
 
 RUN apk add --update $PACKAGES && rm -rf /var/cache/apk/*
-
-

--- a/curl-ssl/curl-ssl_spec.rb
+++ b/curl-ssl/curl-ssl_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'docker'
 require 'serverspec'
 
-CURL_SSL_PACKAGES = "curl openssl ca-certificates"
+CURL_SSL_PACKAGES = "gettext curl openssl ca-certificates"
 
 describe "curl-ssl image" do
   before(:all) {


### PR DESCRIPTION
Exactly the same explanation as in #137, but for curl-ssl.

This is specifically needed to simplify the deployment of new grafana dashboards