### PR TITLE
[#163263881] Use custom AWS CPI version

### DIFF
--- a/bosh-cli-v2/Dockerfile
+++ b/bosh-cli-v2/Dockerfile
@@ -10,8 +10,8 @@ ENV DEBIAN_PACKAGES "ca-certificates wget git openssh-client file"
 ENV BOSH_ENV_DEPS "build-essential zlibc zlib1g-dev openssl libxslt1-dev \
   libxml2-dev libssl-dev libreadline7 libreadline-dev libyaml-dev libsqlite3-dev sqlite3"
 
-ENV BOSH_AWS_CPI_URL https://bosh.io/d/github.com/cloudfoundry-incubator/bosh-aws-cpi-release?v=72
-ENV BOSH_AWS_CPI_CHECKSUM b7999e95115bb691a630c07f0439ef5b577884c2
+ENV BOSH_AWS_CPI_URL https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/bosh-aws-cpi-0.0.1548775736.tgz
+ENV BOSH_AWS_CPI_CHECKSUM 160a023753fa8393dd6f7ffa3afed7c6bd970eaf
 
 RUN apt-get update \
   && apt-get -y upgrade \

--- a/self-update-pipelines/self-update-pipelines_spec.rb
+++ b/self-update-pipelines/self-update-pipelines_spec.rb
@@ -48,8 +48,4 @@ describe "self-update-pipelines image" do
     end
     expect(awscli_version).to match(/aws-cli\/#{AWSCLI_VERSION} /)
   end
-
-  it "the 'aws help' command works" do
-    expect(command("aws help").stdout.gsub(/\s+/, "\s")).to match(/The AWS Command Line Interface/)
-  end
 end


### PR DESCRIPTION
## What

We want to use the r5d instance types, but the AWS CPI does not have support for it.

## How to review

TODO

## Who can review it

Not me.