### PR TITLE
BAU: Update to use bundler 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ language: ruby
 rvm:
   - 2.5
 
+before_install:
+  - gem update --system
+  - gem install bundler
+
 sudo: required
 
 services:


### PR DESCRIPTION
- The push/PR builds are failing due to bundler not being installed
- Travis docs here
  https://docs.travis-ci.com/user/languages/ruby/#bundler-20 suggest
that we need to install bundler 2.0 explicitly