### PR TITLE
Pin ruby to 2.5.1 in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 rvm:
-  - 2.5
+  - 2.5.1
 
 sudo: required
 


### PR DESCRIPTION
The latest version of 2.5 has a different default bundler. This is the
easiest way of making sure our travis builds work.