### PR TITLE
Fix git-ssh image

### DIFF
--- a/git-ssh/Dockerfile
+++ b/git-ssh/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.9
 
-ENV PACKAGES "git openssh-client gnupg bash"
+ENV PACKAGES "git openssl curl openssh-client gnupg bash"
 
 RUN apk add --no-cache $PACKAGES
 

--- a/git-ssh/git-ssh_spec.rb
+++ b/git-ssh/git-ssh_spec.rb
@@ -25,6 +25,18 @@ describe "image" do
     expect(command('git --version').exit_status).to eq(0)
   end
 
+  it "can run curl" do
+    expect(command('curl --version').exit_status).to eq(0)
+  end
+
+  it "can run openssl" do
+    expect(command('openssl version').exit_status).to eq(0)
+  end
+
+  it "has ca-certificates installed" do
+    expect(command('apk list ca-certificates').stdout).to contain('installed')
+  end
+
   it "can run ssh" do
     expect(command('ssh -V').exit_status).to eq(0)
   end


### PR DESCRIPTION
Closes #155

What
---

Our `git-ssh/README.md` says `curl` and `openssl` are installed. They were not, now:

- Adds tests for curl and openssl
- Has them installed

How to review
---

Code review