### PR TITLE
Update awscli version to 1.16.154

### DIFF
--- a/awscli/Dockerfile
+++ b/awscli/Dockerfile
@@ -1,6 +1,6 @@
 FROM governmentpaas/curl-ssl
 
-ENV AWSCLI_VERSION "1.14.10"
+ENV AWSCLI_VERSION "1.16.154"
 ENV PACKAGES "groff less python py-pip jq"
 
 RUN apk add --no-cache $PACKAGES \

--- a/awscli/awscli_spec.rb
+++ b/awscli/awscli_spec.rb
@@ -5,7 +5,7 @@ require 'serverspec'
 AWSCLI_PACKAGES = "curl openssl ca-certificates less"
 
 AWSCLI_BIN = "/usr/bin/aws"
-AWSCLI_VERSION = "1.14.10"
+AWSCLI_VERSION = "1.16.154"
 
 describe "awscli image" do
   before(:all) {


### PR DESCRIPTION
We need to use some of the more recent features of the AWS API via the
command line application provided by this image.