### PR TITLE
Bump CF CLI to v6.45

### DIFF
--- a/cf-cli/Dockerfile
+++ b/cf-cli/Dockerfile
@@ -11,7 +11,6 @@ ENV CF_AUTOPILOT_TEMPFILE "/tmp/autopilot-linux"
 ENV SPRUCE_VERSION "1.17.0"
 
 RUN apk add --no-cache $PACKAGES
-RUN ln -s /lib/ /lib64 # FIXME: Remove for Alpine >= 3.6
 
 RUN curl -L "https://cli.run.pivotal.io/stable?release=linux64-binary&version=${CF_CLI_VERSION}" | tar -zx -C /usr/local/bin
 

--- a/cf-cli/Dockerfile
+++ b/cf-cli/Dockerfile
@@ -1,7 +1,7 @@
 FROM ruby:2.6-alpine3.9
 
 ENV PACKAGES "unzip curl openssl ca-certificates git libc6-compat bash jq"
-ENV CF_CLI_VERSION "6.41.0"
+ENV CF_CLI_VERSION "6.45.0"
 ENV CF_BGD_VERSION "1.3.0"
 ENV CF_BGD_CHECKSUM "c74995ae0ba3ec9eded9c2a555e5984ba536d314cf9dc30013c872eb6b9d76b6"
 ENV CF_BGD_TEMPFILE "/tmp/blue-green-deploy.linux64"

--- a/cf-cli/cf-cli_spec.rb
+++ b/cf-cli/cf-cli_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'docker'
 require 'serverspec'
 
-CF_CLI_VERSION="6.41.0"
+CF_CLI_VERSION="6.45.0"
 SPRUCE_BIN = "/usr/local/bin/spruce"
 SPRUCE_VERSION = "1.17.0"
 


### PR DESCRIPTION
What
---

- Update CF CLI 6.45 in cf-cli docker image
- Remove old FIXME for alpine 3.6

Why
---

So we can run the latest CATS

How to review
---

Code review

Travis