### PR TITLE
Update CF CLI version

### DIFF
--- a/cf-acceptance-tests/Dockerfile
+++ b/cf-acceptance-tests/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:trusty
+FROM ubuntu:xenial
 
 RUN \
   apt-get update && \
@@ -14,6 +14,7 @@ RUN \
 
 ENV GOPATH /go
 ENV PATH /go/bin:/usr/local/go/bin:$PATH
+ENV CF_CLI_VERSION "6.45.0"
 RUN \
   wget https://storage.googleapis.com/golang/go1.9.linux-amd64.tar.gz -P /tmp && \
   tar xzvf /tmp/go1.9.linux-amd64.tar.gz -C /usr/local && \
@@ -24,7 +25,7 @@ RUN go get github.com/tools/godep
 RUN go get github.com/onsi/ginkgo/ginkgo
 
 # Install the cf CLI
-RUN wget -q -O cf.deb "https://cli.run.pivotal.io/stable?release=debian64&version=6.39.1&source=github-rel" && \
+RUN wget -q -O cf.deb "https://cli.run.pivotal.io/stable?release=debian64&version=${CF_CLI_VERSION}&source=github-rel" && \
     dpkg -i cf.deb && \
     rm -f cf.deb
 

--- a/cf-acceptance-tests/Dockerfile
+++ b/cf-acceptance-tests/Dockerfile
@@ -14,7 +14,10 @@ RUN \
 
 ENV GOPATH /go
 ENV PATH /go/bin:/usr/local/go/bin:$PATH
+
 ENV CF_CLI_VERSION "6.45.0"
+ENV CF_LOG_CACHE_VERSION "2.1.0"
+
 RUN \
   wget https://storage.googleapis.com/golang/go1.9.linux-amd64.tar.gz -P /tmp && \
   tar xzvf /tmp/go1.9.linux-amd64.tar.gz -C /usr/local && \
@@ -33,7 +36,7 @@ RUN wget -q -O cf.deb "https://cli.run.pivotal.io/stable?release=debian64&versio
 ENV CF_PLUGIN_HOME /root/
 
 # Install the log-cache-cli plugin
-RUN cf install-plugin -f https://github.com/cloudfoundry/log-cache-cli/releases/download/v2.0.0/log-cache-cf-plugin-linux
+RUN cf install-plugin -f "https://github.com/cloudfoundry/log-cache-cli/releases/download/v${CF_LOG_CACHE_VERSION}/log-cache-cf-plugin-linux"
 
 # Install the AWS-CLI
 RUN pip install awscli=="1.14.10"

--- a/cf-acceptance-tests/cf-acceptance-tests_spec.rb
+++ b/cf-acceptance-tests/cf-acceptance-tests_spec.rb
@@ -4,7 +4,7 @@ require 'serverspec'
 
 GO_VERSION="1.9"
 CF_CLI_VERSION="6.45.0"
-LOG_CACHE_CLI_VERSION="2.0.0"
+LOG_CACHE_CLI_VERSION="2.1.0"
 
 describe "cf-acceptance-tests image" do
   before(:all) {
@@ -62,6 +62,9 @@ describe "cf-acceptance-tests image" do
     plugins_output = command("cf plugins").stdout
     expect(plugins_output).to match(/^log-cache +#{LOG_CACHE_CLI_VERSION} +log-meta/)
     expect(plugins_output).to match(/^log-cache +#{LOG_CACHE_CLI_VERSION} +tail /)
+
+    cf_tail_help = command("cf tail -h").stdout
+    expect(cf_tail_help).to match(/envelope-class/)
   end
 
   it "has AWS CLI available" do

--- a/cf-acceptance-tests/cf-acceptance-tests_spec.rb
+++ b/cf-acceptance-tests/cf-acceptance-tests_spec.rb
@@ -3,7 +3,7 @@ require 'docker'
 require 'serverspec'
 
 GO_VERSION="1.9"
-CF_CLI_VERSION="6.39.1"
+CF_CLI_VERSION="6.45.0"
 LOG_CACHE_CLI_VERSION="2.0.0"
 
 describe "cf-acceptance-tests image" do


### PR DESCRIPTION
We need to update the CF CLI version due to changes in commands in CF 9.x series. I have updated the tests and also changed the base container to a Xenial container.