### PR TITLE
Upgrade go to latest version for acceptance tests

### DIFF
--- a/cf-acceptance-tests/Dockerfile
+++ b/cf-acceptance-tests/Dockerfile
@@ -15,12 +15,13 @@ RUN \
 ENV GOPATH /go
 ENV PATH /go/bin:/usr/local/go/bin:$PATH
 
+ENV GO_VERSION "1.12.5"
 ENV CF_CLI_VERSION "6.45.0"
 ENV CF_LOG_CACHE_VERSION "2.1.0"
 
 RUN \
-  wget https://storage.googleapis.com/golang/go1.9.linux-amd64.tar.gz -P /tmp && \
-  tar xzvf /tmp/go1.9.linux-amd64.tar.gz -C /usr/local && \
+  wget https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz -P /tmp && \
+  tar xzvf /tmp/go${GO_VERSION}.linux-amd64.tar.gz -C /usr/local && \
   mkdir $GOPATH && \
   rm -rf /tmp/*
 

--- a/cf-acceptance-tests/cf-acceptance-tests_spec.rb
+++ b/cf-acceptance-tests/cf-acceptance-tests_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'docker'
 require 'serverspec'
 
-GO_VERSION="1.9"
+GO_VERSION="1.12.5"
 CF_CLI_VERSION="6.45.0"
 LOG_CACHE_CLI_VERSION="2.1.0"
 


### PR DESCRIPTION
The acceptance tests are now using go modules. As a result we need a suitable version of go in the container.