### PR TITLE
[#167971884] Allow non-interactive bosh-shell usage

### DIFF
--- a/bosh-shell/Dockerfile
+++ b/bosh-shell/Dockerfile
@@ -23,4 +23,4 @@ RUN wget -nv https://github.com/cloudfoundry-incubator/credhub-cli/releases/down
 
 COPY startup.sh /startup.sh
 
-ENTRYPOINT /startup.sh
+ENTRYPOINT ["/startup.sh"]

--- a/bosh-shell/startup.sh
+++ b/bosh-shell/startup.sh
@@ -22,4 +22,4 @@ export BOSH_GW_HOST=$BOSH_IP
 export BOSH_GW_USER=vcap
 export BOSH_GW_PRIVATE_KEY=/tmp/bosh_id_rsa
 
-exec bash
+exec bash "${@}"


### PR DESCRIPTION
What
---
Now that we configure credhub CLI as part of this container, we have reasonable
call to use it to access secrets in a non-interactive fashion as part of our
dev tooling. This PR feeds the command used to run the container through to the
bash shell started in `startup.sh`.

In order to correctly run a command, scripts should prefix their commands with
`-c`, as if they were running `bash -c 'command'" (which they are). E.g.

```
docker run \
  --rm \
  governmentpaas/bosh-shell:latest \
  "-c 'credhub --version'"
```

Interactive usage should continue to function as normal when the container is
run interactively without a command. E.g.

```
docker run -it --rm governmentpaas/bosh-shell:latest
```

How to review
---
1. Code review
2. Build it locally and make a couple test scripts for the different usages based on its current usage in `paas-bootstrap`

Who can review
---
Anyone