### PR TITLE
[DO NOT MERGE] Make cf-cli image build with cf7 CLI

### DIFF
--- a/cf-cli/Dockerfile
+++ b/cf-cli/Dockerfile
@@ -1,32 +1,13 @@
 FROM ruby:2.6-alpine3.9
 
 ENV PACKAGES "unzip curl openssl ca-certificates git libc6-compat bash jq gettext"
-ENV CF_CLI_VERSION "6.45.0"
-ENV CF_BGD_VERSION "1.3.0"
-ENV CF_BGD_CHECKSUM "c74995ae0ba3ec9eded9c2a555e5984ba536d314cf9dc30013c872eb6b9d76b6"
-ENV CF_BGD_TEMPFILE "/tmp/blue-green-deploy.linux64"
-ENV CF_AUTOPILOT_VERSION "0.0.4"
-ENV CF_AUTOPILOT_CHECKSUM "a755f9da3981fb6dc6aa675a55f8fc7de9d73c87b8cad4883d98c543a45a9922"
-ENV CF_AUTOPILOT_TEMPFILE "/tmp/autopilot-linux"
+ENV CF_CLI_VERSION "7.0.0-beta.25"
 ENV SPRUCE_VERSION "1.17.0"
 
 RUN apk add --no-cache $PACKAGES
 
-RUN curl -L "https://cli.run.pivotal.io/stable?release=linux64-binary&version=${CF_CLI_VERSION}" | tar -zx -C /usr/local/bin
-
-RUN curl -L -o "${CF_BGD_TEMPFILE}" \
-  "https://github.com/bluemixgaragelondon/cf-blue-green-deploy/releases/download/v${CF_BGD_VERSION}/blue-green-deploy.linux64" \
-  && echo "${CF_BGD_CHECKSUM}  ${CF_BGD_TEMPFILE}" | sha256sum -c - \
-  && chmod +x "${CF_BGD_TEMPFILE}" \
-  && cf install-plugin -f "${CF_BGD_TEMPFILE}" \
-  && rm "${CF_BGD_TEMPFILE}"
-
-RUN curl -L -o "${CF_AUTOPILOT_TEMPFILE}" \
-  "https://github.com/contraband/autopilot/releases/download/${CF_AUTOPILOT_VERSION}/autopilot-linux" \
-  && echo "${CF_AUTOPILOT_CHECKSUM}  ${CF_AUTOPILOT_TEMPFILE}" | sha256sum -c - \
-  && chmod +x "${CF_AUTOPILOT_TEMPFILE}" \
-  && cf install-plugin -f "${CF_AUTOPILOT_TEMPFILE}" \
-  && rm "${CF_AUTOPILOT_TEMPFILE}"
+RUN curl -L "https://packages.cloudfoundry.org/stable?release=linux64-binary&version=${CF_CLI_VERSION}" | tar -zx -C /tmp
+RUN cp /tmp/cf7 /usr/local/bin/cf
 
 RUN curl -Lo /usr/local/bin/spruce https://github.com/geofffranks/spruce/releases/download/v${SPRUCE_VERSION}/spruce-linux-amd64 \
   && chmod +x /usr/local/bin/spruce

--- a/cf-cli/cf-cli_spec.rb
+++ b/cf-cli/cf-cli_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'docker'
 require 'serverspec'
 
-CF_CLI_VERSION="6.45.0"
+CF_CLI_VERSION="7.0.0-beta.25"
 SPRUCE_BIN = "/usr/local/bin/spruce"
 SPRUCE_VERSION = "1.17.0"
 
@@ -15,16 +15,6 @@ describe "cf-cli image" do
     expect(
       command("cf --version").stdout
     ).to match(/cf version #{CF_CLI_VERSION}/)
-  end
-
-  it "has blue-green-deploy plugin available" do
-    cmd = command("cf blue-green-deploy --help")
-    expect(cmd.exit_status).to eq(0)
-  end
-
-  it "has autopilot plugin available" do
-    cmd = command("cf zero-downtime-push --help")
-    expect(cmd.exit_status).to eq(0)
   end
 
   it "has curl available" do


### PR DESCRIPTION
:warning: Do not merge (very breaking change) :warning: 

I've raised this PR so dockerhub will build an image with the branch name as the tag :upside_down_face: 

Add cf7 CLI and remove bgd and autopilot plugins that aren't needed