### PR TITLE
Update terraform to 0.11.14 and terraform-provider-aws to 2.30.0

### DIFF
--- a/terraform/Dockerfile
+++ b/terraform/Dockerfile
@@ -1,8 +1,8 @@
 FROM alpine:3.9
 
 ENV PATH $PATH:/usr/local/bin
-ENV TERRAFORM_VER 0.11.1
-ENV TERRAFORM_SUM 4e3d5e4c6a267e31e9f95d4c1b00f5a7be5a319698f0370825b459cb786e2f35
+ENV TERRAFORM_VER 0.11.14
+ENV TERRAFORM_SUM 9b9a4492738c69077b079e595f5b2a9ef1bc4e8fb5596610f69a6f322a8af8dd
 ENV TERRAFORM_ZIP terraform_${TERRAFORM_VER}_linux_amd64.zip
 
 RUN apk add --no-cache openssl openssh-client ca-certificates

--- a/terraform/plugin_cache.tf
+++ b/terraform/plugin_cache.tf
@@ -1,5 +1,5 @@
 provider "aws" {
-  version = "1.46.0"
+  version = "2.30.0"
 }
 provider "datadog" {
   version = "1.0.3"

--- a/terraform/terraform_spec.rb
+++ b/terraform/terraform_spec.rb
@@ -18,7 +18,7 @@ describe "Terraform image" do
   it "has the expected Terraform version" do
     expect(
       command("terraform version").stdout
-    ).to include("Terraform v0.11.1")
+    ).to match("Terraform v0.11.1$")
   end
 
   it "installs SSH" do

--- a/terraform/terraform_spec.rb
+++ b/terraform/terraform_spec.rb
@@ -18,7 +18,7 @@ describe "Terraform image" do
   it "has the expected Terraform version" do
     expect(
       command("terraform version").stdout
-    ).to match("Terraform v0.11.1$")
+    ).to match("Terraform v0.11.14$")
   end
 
   it "installs SSH" do


### PR DESCRIPTION
What
----

Updates terraform to 0.11.14 and terraform-provider-aws to 2.30.0

We experience crashes when creating (and sometimes deleting) using our very old version of terraform 0.11.1 and terraform-provider-aws 1.46

Bump the images

Once the images are built we can test the later versions in pipelines to see if things are tangibly better

How to review
---

```
git fetch
git checkout -b terraform0.11.14 origin/!#:3
rake build:terraform
rake test:terraform
```