### PR TITLE
[Firebreak] Add jq to curl-ssl image

### DIFF
--- a/curl-ssl/Dockerfile
+++ b/curl-ssl/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:3.9
 
-ENV PACKAGES "gettext curl openssl ca-certificates"
+ENV PACKAGES "jq gettext curl openssl ca-certificates"
 
 RUN apk add --no-cache $PACKAGES

--- a/curl-ssl/curl-ssl_spec.rb
+++ b/curl-ssl/curl-ssl_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'docker'
 require 'serverspec'
 
-CURL_SSL_PACKAGES = "gettext curl openssl ca-certificates"
+CURL_SSL_PACKAGES = "jq gettext curl openssl ca-certificates"
 
 describe "curl-ssl image" do
   before(:all) {


### PR DESCRIPTION
It would be really useful to have `jq` available in the `curl-ssl` image, so json responses can be parsed easily.

This change adds that tool.