### PR TITLE
Add make to cf-cli image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 rvm:
-  - 2.5.1
+  - 2.5.3
 
 sudo: required
 

--- a/cf-cli/Dockerfile
+++ b/cf-cli/Dockerfile
@@ -1,6 +1,6 @@
 FROM ruby:2.6-alpine3.9
 
-ENV PACKAGES "unzip curl openssl ca-certificates git libc6-compat bash jq gettext"
+ENV PACKAGES "unzip curl openssl ca-certificates git libc6-compat bash jq gettext make"
 ENV CF_CLI_VERSION "6.45.0"
 ENV CF_BGD_VERSION "1.3.0"
 ENV CF_BGD_CHECKSUM "c74995ae0ba3ec9eded9c2a555e5984ba536d314cf9dc30013c872eb6b9d76b6"

--- a/cf-cli/cf-cli_spec.rb
+++ b/cf-cli/cf-cli_spec.rb
@@ -33,6 +33,12 @@ describe "cf-cli image" do
     ).to eq(0)
   end
 
+  it "has make available" do
+    expect(
+      command("make --version").exit_status
+    ).to eq(0)
+  end
+
   it "has unzip available" do
     expect(
       command("unzip -v").exit_status


### PR DESCRIPTION
- Notify in particular need make along with the cf-cli for doing
  deployments on Concourse
- Add a package and test for that package to include make in the image