### PR TITLE
Update cf cli to v 6.46.1

### DIFF
--- a/cf-cli/Dockerfile
+++ b/cf-cli/Dockerfile
@@ -1,7 +1,7 @@
 FROM ruby:2.6-alpine3.9
 
 ENV PACKAGES "unzip curl openssl ca-certificates git libc6-compat bash jq gettext make"
-ENV CF_CLI_VERSION "6.45.0"
+ENV CF_CLI_VERSION "6.46.1"
 ENV CF_BGD_VERSION "1.3.0"
 ENV CF_BGD_CHECKSUM "c74995ae0ba3ec9eded9c2a555e5984ba536d314cf9dc30013c872eb6b9d76b6"
 ENV CF_BGD_TEMPFILE "/tmp/blue-green-deploy.linux64"

--- a/cf-cli/cf-cli_spec.rb
+++ b/cf-cli/cf-cli_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'docker'
 require 'serverspec'
 
-CF_CLI_VERSION="6.45.0"
+CF_CLI_VERSION="6.46.1"
 SPRUCE_BIN = "/usr/local/bin/spruce"
 SPRUCE_VERSION = "1.17.0"
 


### PR DESCRIPTION
Bump version of cf-cli used in governmentpaas/cf-cli container to
latest (currently v6.46.1, v7.x still in beta)