### PR TITLE
[#166500017] Add option to pass in a user's key

### DIFF
--- a/bosh-shell/startup.sh
+++ b/bosh-shell/startup.sh
@@ -2,13 +2,13 @@
 
 set -eu
 
-if [ -z "${BOSH_ID_RSA:-}" ] || [ -z "${BOSH_IP:-}" ] || [ -z "${BOSH_ENVIRONMENT:-}" ] || [ -z "${BOSH_CA_CERT:-}" ]; then
-  echo "WARNING: You need to set BOSH_ID_RSA, BOSH_IP, BOSH_ENVIRONMENT and BOSH_CA_CERT."
+if [ -z "${USER_ID_RSA:-}" ] || [ -z "${BOSH_IP:-}" ] || [ -z "${BOSH_ENVIRONMENT:-}" ] || [ -z "${BOSH_CA_CERT:-}" ]; then
+  echo "WARNING: You need to set USER_ID_RSA, BOSH_IP, BOSH_ENVIRONMENT and BOSH_CA_CERT."
   echo "You will not be logged into Bosh."
   exec bash
 fi
 
-echo "$BOSH_ID_RSA" | base64 -d > /tmp/bosh_id_rsa && chmod 400 /tmp/bosh_id_rsa
+echo "$USER_ID_RSA" | base64 -d > /tmp/user_id_rsa && chmod 400 /tmp/user_id_rsa
 
 ssh -fNC -4 -D 25555 \
   -o ExitOnForwardFailure=yes \
@@ -16,11 +16,11 @@ ssh -fNC -4 -D 25555 \
   -o UserKnownHostsFile=/dev/null \
   -o ServerAliveInterval=30 \
   -q \
-  "vcap@$BOSH_IP" -i /tmp/bosh_id_rsa
+  "$USER"@"$BOSH_IP" -i /tmp/user_id_rsa
 
 export BOSH_ALL_PROXY="socks5://localhost:25555"
 export BOSH_GW_HOST=$BOSH_IP
-export BOSH_GW_USER=vcap
-export BOSH_GW_PRIVATE_KEY=/tmp/bosh_id_rsa
+export BOSH_GW_USER=$USER
+export BOSH_GW_PRIVATE_KEY=/tmp/user_id_rsa
 
 exec bash "${@}"


### PR DESCRIPTION
What
---

We're switching to use individual accounts instead of shared creds. This updates the bosh-shell image with a USER_ID_RSA var so we can pass in user specific keys.

How to review
---

- Code review
- Build locally and update image used [here](https://github.com/alphagov/paas-bootstrap/compare/indiviual-accounts-166500017?expand=1#diff-1f5c6bd196a437e4dca5a2c70344b48cL50)

Who can review
---

Not me