### PR TITLE
bump to latest awscli version

### DIFF
--- a/awscli/Dockerfile
+++ b/awscli/Dockerfile
@@ -1,6 +1,6 @@
 FROM governmentpaas/curl-ssl
 
-ENV AWSCLI_VERSION "1.16.154"
+ENV AWSCLI_VERSION "1.17.2"
 ENV PACKAGES "groff less python py-pip jq"
 
 RUN apk add --no-cache $PACKAGES \

--- a/awscli/awscli_spec.rb
+++ b/awscli/awscli_spec.rb
@@ -5,7 +5,7 @@ require 'serverspec'
 AWSCLI_PACKAGES = "curl openssl ca-certificates less"
 
 AWSCLI_BIN = "/usr/bin/aws"
-AWSCLI_VERSION = "1.16.154"
+AWSCLI_VERSION = "1.17.2"
 
 describe "awscli image" do
   before(:all) {

--- a/self-update-pipelines/Dockerfile
+++ b/self-update-pipelines/Dockerfile
@@ -1,6 +1,6 @@
 FROM ruby:2.6-slim
 
-ENV AWSCLI_VERSION "1.16.140"
+ENV AWSCLI_VERSION "1.17.2"
 ENV PACKAGES make python-setuptools python-pip groff less curl
 
 RUN apt-get update \

--- a/self-update-pipelines/self-update-pipelines_spec.rb
+++ b/self-update-pipelines/self-update-pipelines_spec.rb
@@ -3,7 +3,7 @@ require 'docker'
 require 'serverspec'
 
 AWSCLI_BIN = "/usr/local/bin/aws"
-AWSCLI_VERSION = "1.16.140"
+AWSCLI_VERSION = "1.17.2"
 
 describe "self-update-pipelines image" do
   before(:all) {


### PR DESCRIPTION
My selfish reason for wanting this is to get support for the [k8s IAM
magical auth support][1] but it's probably good to keep updating this
for all sorts of reasons.

1.17.0 dropped support for python 2.6 and 3.3; I don't think that's a
concern for us here?

[1]: https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts-minimum-sdk.html