### PR TITLE
Upgrade terraform to 0.13.3

### DIFF
--- a/terraform/Dockerfile
+++ b/terraform/Dockerfile
@@ -1,8 +1,8 @@
 FROM alpine:3.12
 
 ENV PATH $PATH:/usr/local/bin
-ENV TERRAFORM_VER 0.13.2
-ENV TERRAFORM_SUM 6c1c6440c5cb199e85926aea65773450564f501fddcd7876f453ba95b45ba746
+ENV TERRAFORM_VER 0.13.3
+ENV TERRAFORM_SUM 35c662be9d32d38815cde5fa4c9fa61a3b7f39952ecd50ebf92fd1b2ddd6109b
 ENV TERRAFORM_ZIP terraform_${TERRAFORM_VER}_linux_amd64.zip
 
 RUN apk add --no-cache openssl openssh-client ca-certificates

--- a/terraform/terraform_spec.rb
+++ b/terraform/terraform_spec.rb
@@ -18,7 +18,7 @@ describe "Terraform image" do
   it "has the expected Terraform version" do
     expect(
       command("terraform version").stdout
-    ).to match("Terraform v0.13.2$")
+    ).to match("Terraform v0.13.3$")
   end
 
   it "installs SSH" do


### PR DESCRIPTION
The GOV.UK replatforming team are using 0.13.3, but we're too lazy to
build our own docker images at this point in time.