### PR TITLE
Bump awscli version

### DIFF
--- a/awscli/Dockerfile
+++ b/awscli/Dockerfile
@@ -1,6 +1,6 @@
 FROM governmentpaas/curl-ssl
 
-ENV AWSCLI_VERSION "1.17.2"
+ENV AWSCLI_VERSION "1.18.140"
 ENV PACKAGES "groff less python3 py-pip jq"
 
 RUN apk add --no-cache $PACKAGES \


### PR DESCRIPTION
Per https://github.com/boto/boto3/issues/2596#issuecomment-694508466

The PaaS might not use this but we've seen it when re-using the image for
OctoDNS and trying to `pip3 install boto3` on top of governmentpaas/awscli.