### PR TITLE
[#176226306] Build mirrored DockerHub images for us to use in production

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,0 +1,1 @@
+FROM alpine:3.12

--- a/alpine/README.md
+++ b/alpine/README.md
@@ -1,0 +1,12 @@
+Provides Alpine Linux. See the Dockerfile to check which version.
+
+For now this container is merely a mirror of DockerHub's `alpine`. The
+purpose is to get that container onto GitHub Container Registry, to
+workaround rate limits and make our production use a bit safer.
+
+## Build locally
+
+```
+$ cd alpine
+$ docker build -t alpine .
+```

--- a/concourse-pool-resource/Dockerfile
+++ b/concourse-pool-resource/Dockerfile
@@ -1,0 +1,1 @@
+FROM concourse/pool-resource:1.1.1

--- a/concourse-pool-resource/README.md
+++ b/concourse-pool-resource/README.md
@@ -1,0 +1,14 @@
+Provides the Concourse Pool Resource. See the Dockerfile to check
+which version.
+
+For now this container is merely a mirror of DockerHub's
+`concourse/pool-resource`. The purpose is to get that container onto
+GitHub Container Registry, to workaround rate limits and make our
+production use a bit safer.
+
+## Build locally
+
+```
+$ cd concourse-pool-resource
+$ docker build -t concourse-pool-resource .
+```

--- a/golang/Dockerfile
+++ b/golang/Dockerfile
@@ -1,0 +1,1 @@
+FROM golang:1.14

--- a/node/Dockerfile
+++ b/node/Dockerfile
@@ -1,0 +1,1 @@
+FROM node:lts-alpine

--- a/olhtbr-metadata-resource/Dockerfile
+++ b/olhtbr-metadata-resource/Dockerfile
@@ -1,0 +1,1 @@
+FROM olhtbr/metadata-resource:2.0.1

--- a/ruby/Dockerfile
+++ b/ruby/Dockerfile
@@ -1,0 +1,1 @@
+FROM ruby:2.7-slim

--- a/ruby/README.md
+++ b/ruby/README.md
@@ -1,0 +1,18 @@
+Provides Ruby. See the Dockerfile to check which version.
+
+For now this container is merely a mirror of DockerHub's `ruby`. The
+purpose is to get that container onto GitHub Container Registry,
+to workaround rate limits and make our production use a bit safer.
+
+## Build locally
+
+```
+$ cd psql
+$ docker build -t ruby .
+```
+
+## Run
+
+```
+docker run -i ruby irb
+```


### PR DESCRIPTION
## What

DockerHub recently started rate limiting. As a result we are stopping using DockerHub for high-volume production CI/CD pipelines. This commit finishes off that work.

This commit creates 3 new Dockerfiles corresponding to the 3 remaining uses of DockerHub in our pipelines. We want to use GitHub Container Registry, but these external images aren't available there yet.

Alternative is to have something copy these 3 upstream images across to GitHub Container Registry, but that doesn't fit with the existing pattern we have in this repo.

## How to review

See if things go green, and decide if you're OK with this approach.

Once this is merged there's then https://github.com/alphagov/paas-release-ci/pull/162 to review, which builds these images and pushes them to GCHR.