### PR TITLE
spruce: bump to v1.27.0

### DIFF
--- a/spruce/Dockerfile
+++ b/spruce/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.12
 
-ENV SPRUCE_VERSION 1.22.0
+ENV SPRUCE_VERSION 1.27.0
 
 RUN apk add --no-cache wget ca-certificates \
   && wget https://github.com/geofffranks/spruce/releases/download/v${SPRUCE_VERSION}/spruce-linux-amd64 \

--- a/spruce/spruce_spec.rb
+++ b/spruce/spruce_spec.rb
@@ -3,7 +3,7 @@ require 'docker'
 require 'serverspec'
 
 SPRUCE_BIN = "/usr/local/bin/spruce"
-SPRUCE_VERSION = "1.22.0"
+SPRUCE_VERSION = "1.27.0"
 ALPINE_VERSION = "3.12"
 
 describe "spruce image" do


### PR DESCRIPTION
Spruce bump is required to be consistent with embedded spruce in cf-cli image.
This is related to  #203