### PR TITLE
Bump bosh-cli, bosh-aws-cpi, credhub-cli versions

### DIFF
--- a/bosh-cli-v2/Dockerfile
+++ b/bosh-cli-v2/Dockerfile
@@ -1,7 +1,7 @@
 FROM ruby:2.7-slim
 
-ENV BOSH_CLI_VERSION 6.4.1
-ENV BOSH_CLI_SUM 756d8e403f1d349ef3766d28980379c24da6212fa45dcf296c0519d4ec54d66a
+ENV BOSH_CLI_VERSION 6.4.4
+ENV BOSH_CLI_SUM c944dd694e5470686995c2365ac60c9ef06f655cab51994f7fefed4c89e764fb
 ENV BOSH_CLI_FILENAME bosh-cli-${BOSH_CLI_VERSION}-linux-amd64
 
 ENV DEBIAN_PACKAGES "ca-certificates wget git openssh-client file"
@@ -10,8 +10,8 @@ ENV DEBIAN_PACKAGES "ca-certificates wget git openssh-client file"
 ENV BOSH_ENV_DEPS "build-essential zlibc zlib1g-dev openssl libxslt1-dev \
   libxml2-dev libssl-dev libreadline7 libreadline-dev libyaml-dev libsqlite3-dev sqlite3"
 
-ENV BOSH_AWS_CPI_URL https://bosh.io/d/github.com/cloudfoundry/bosh-aws-cpi-release?v=82
-ENV BOSH_AWS_CPI_CHECKSUM 1a4826469e715f5595de38a15df7b7f511fbfe85
+ENV BOSH_AWS_CPI_URL https://bosh.io/d/github.com/cloudfoundry/bosh-aws-cpi-release?v=87
+ENV BOSH_AWS_CPI_CHECKSUM a920cd1bdead3d6167273e763912becca2225ba6
 
 RUN apt-get update \
   && apt-get -y upgrade \
@@ -28,8 +28,8 @@ COPY bosh_init_cache /tmp/bosh_init_cache/
 RUN /tmp/bosh_init_cache/seed_bosh_init_cache.sh && \
     rm -rf /tmp/bosh_init_cache
 
-ENV CREDHUB_CLI_VERSION 2.8.0
-ENV CREDHUB_CLI_SUM dcd4f05eaaea6f356d8ffcbf2692c465b272fcdf773266589f4bc4a891cbe4e4
+ENV CREDHUB_CLI_VERSION 2.9.0
+ENV CREDHUB_CLI_SUM f260e926099f9eb9474ab2239851e391bfd0fd1354a52891f3c834cea1630e8a
 ENV CREDHUB_CLI_FILENAME credhub-linux-${CREDHUB_CLI_VERSION}.tgz
 
 RUN wget -nv https://github.com/cloudfoundry-incubator/credhub-cli/releases/download/${CREDHUB_CLI_VERSION}/${CREDHUB_CLI_FILENAME} \

--- a/bosh-cli-v2/bosh-cli_spec.rb
+++ b/bosh-cli-v2/bosh-cli_spec.rb
@@ -2,8 +2,8 @@ require 'spec_helper'
 require 'docker'
 require 'serverspec'
 
-BOSH_CLI_VERSION="6.4.1-35ce8438-2020-10-20T16:04:13Z"
-CREDHUB_VERSION='2.8.0'
+BOSH_CLI_VERSION="6.4.4-3c1a893c-2021-06-11T20:26:27Z"
+CREDHUB_VERSION='2.9.0'
 
 BOSH_ENV_DEPS = "build-essential zlibc zlib1g-dev openssl libxslt1-dev libxml2-dev \
     libssl-dev libreadline7 libreadline-dev libyaml-dev libsqlite3-dev sqlite3"


### PR DESCRIPTION
Latest available versions:

bosh-cli: 6.4.4
bosh-aws-cpi: 87
credhub-cli: 2.9.0

Our bosh stemcell upgrade is blocked by bosh-cli < 6.4.4