### PR TITLE
[#178621826] bosh-cli-v2: add yq

### DIFF
--- a/bosh-cli-v2/Dockerfile
+++ b/bosh-cli-v2/Dockerfile
@@ -37,3 +37,12 @@ RUN wget -nv https://github.com/cloudfoundry-incubator/credhub-cli/releases/down
   && tar zxvf ${CREDHUB_CLI_FILENAME} \
   && chmod +x credhub \
   && mv credhub /usr/local/bin/credhub
+
+ENV YQ_VERSION 4.9.6
+ENV YQ_SUM a1cfa39a9538e27f11066aa5659b32f9beae1eea93369d395bf45bcfc8a181dc
+ENV YQ_FILENAME yq_linux_amd64
+
+RUN wget -nv https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/${YQ_FILENAME} \
+  && echo "${YQ_SUM}  ${YQ_FILENAME}" | sha256sum -c - \
+  && chmod +x ${YQ_FILENAME} \
+  && mv ${YQ_FILENAME} /usr/local/bin/yq

--- a/bosh-cli-v2/bosh-cli_spec.rb
+++ b/bosh-cli-v2/bosh-cli_spec.rb
@@ -53,6 +53,12 @@ describe "bosh-cli-v2 image" do
     ).to eq(0)
   end
 
+  it "has `yq` available" do
+    expect(
+      command("yq --version").exit_status
+    ).to eq(0)
+  end
+
   it "has a new enough version of openssl available" do
     # wget (from busybox) requires openssl to be able to connect to https sites.
 

--- a/bosh-cli-v2/bosh-cli_spec.rb
+++ b/bosh-cli-v2/bosh-cli_spec.rb
@@ -53,6 +53,12 @@ describe "bosh-cli-v2 image" do
     ).to eq(0)
   end
 
+  it "has `jq` available" do
+    expect(
+      command("jq --version").exit_status
+    ).to eq(0)
+  end
+
   it "has `yq` available" do
     expect(
       command("yq --version").exit_status


### PR DESCRIPTION
Can already hear the question "doesn't this make `jq` unnecessary?", answer "no, `yq` is much less powerful than `jq`".

This is so that we can do some very basic value extraction on manifests fetched from bosh in the pipeline.