### PR TITLE
Add node-chromium image

### DIFF
--- a/node-chromium/Dockerfile
+++ b/node-chromium/Dockerfile
@@ -1,0 +1,12 @@
+FROM node:lts-alpine
+
+RUN apk add --no-cache \
+    chromium \
+    nss \
+    freetype \
+    harfbuzz \
+    ca-certificates \
+    ttf-freefont
+
+ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true \
+    PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser


### PR DESCRIPTION
Essentially we need a headless browser to be performing some of our acceptance tests in.