### PR TITLE
cli bump for bosh, cf credhub and spruce

### DIFF
--- a/bosh-cli-v2/Dockerfile
+++ b/bosh-cli-v2/Dockerfile
@@ -1,7 +1,7 @@
 FROM ruby:2.7-slim-buster
 
-ENV BOSH_CLI_VERSION 6.4.4
-ENV BOSH_CLI_SUM c944dd694e5470686995c2365ac60c9ef06f655cab51994f7fefed4c89e764fb
+ENV BOSH_CLI_VERSION 6.4.7
+ENV BOSH_CLI_SUM 596abc123ddb676f081d375dc4672359fb1573c38d8dd3e8bdc4f3d2769783a1
 ENV BOSH_CLI_FILENAME bosh-cli-${BOSH_CLI_VERSION}-linux-amd64
 
 ENV DEBIAN_PACKAGES "ca-certificates wget git openssh-client file jq"
@@ -28,8 +28,8 @@ COPY bosh_init_cache /tmp/bosh_init_cache/
 RUN /tmp/bosh_init_cache/seed_bosh_init_cache.sh && \
     rm -rf /tmp/bosh_init_cache
 
-ENV CREDHUB_CLI_VERSION 2.9.0
-ENV CREDHUB_CLI_SUM f260e926099f9eb9474ab2239851e391bfd0fd1354a52891f3c834cea1630e8a
+ENV CREDHUB_CLI_VERSION 2.9.1
+ENV CREDHUB_CLI_SUM df8aa256d4563d741bda71e4e0baff077addce8438dba4f9157504b387b93d9f
 ENV CREDHUB_CLI_FILENAME credhub-linux-${CREDHUB_CLI_VERSION}.tgz
 
 RUN wget -nv https://github.com/cloudfoundry-incubator/credhub-cli/releases/download/${CREDHUB_CLI_VERSION}/${CREDHUB_CLI_FILENAME} \

--- a/bosh-cli-v2/bosh-cli-v2_spec.rb
+++ b/bosh-cli-v2/bosh-cli-v2_spec.rb
@@ -2,8 +2,8 @@ require 'spec_helper'
 require 'docker'
 require 'serverspec'
 
-BOSH_CLI_VERSION="6.4.4-3c1a893c-2021-06-11T20:26:27Z"
-CREDHUB_VERSION='2.9.0'
+BOSH_CLI_VERSION="6.4.7-44aadb4f-2021-09-17T18:39:29Z"
+CREDHUB_VERSION='2.9.1'
 
 BOSH_ENV_DEPS = "build-essential zlibc zlib1g-dev openssl libxslt1-dev libxml2-dev \
     libssl-dev libreadline7 libreadline-dev libyaml-dev libsqlite3-dev sqlite3"

--- a/cf-cli/Dockerfile
+++ b/cf-cli/Dockerfile
@@ -1,8 +1,8 @@
 FROM ghcr.io/alphagov/paas/ruby-base:main
 
 ENV PACKAGES "unzip curl openssl ca-certificates git libc6-compat bash jq gettext make"
-ENV CF_CLI_VERSION "7.2.0"
-ENV SPRUCE_VERSION "1.27.0"
+ENV CF_CLI_VERSION "7.3.0"
+ENV SPRUCE_VERSION "1.29.0"
 
 RUN apk add --no-cache $PACKAGES
 

--- a/cf-cli/cf-cli_spec.rb
+++ b/cf-cli/cf-cli_spec.rb
@@ -2,9 +2,9 @@ require 'spec_helper'
 require 'docker'
 require 'serverspec'
 
-CF_CLI_VERSION="7.2.0"
+CF_CLI_VERSION="7.3.0"
 SPRUCE_BIN = "/usr/local/bin/spruce"
-SPRUCE_VERSION = "1.27.0"
+SPRUCE_VERSION = "1.29.0"
 
 describe "cf-cli image" do
   before(:all) {

--- a/spruce/Dockerfile
+++ b/spruce/Dockerfile
@@ -1,6 +1,6 @@
 FROM ghcr.io/alphagov/paas/alpine:main
 
-ENV SPRUCE_VERSION 1.27.0
+ENV SPRUCE_VERSION 1.29.0
 
 RUN apk add --no-cache \
         wget=1.21.3-r0 \

--- a/spruce/spruce_spec.rb
+++ b/spruce/spruce_spec.rb
@@ -3,7 +3,7 @@ require 'docker'
 require 'serverspec'
 
 SPRUCE_BIN = "/usr/local/bin/spruce"
-SPRUCE_VERSION = "1.27.0"
+SPRUCE_VERSION = "1.29.0"
 ALPINE_VERSION = "3.13"
 
 describe "spruce image" do


### PR DESCRIPTION
- bosh cli: [6.4.7](https://github.com/cloudfoundry/bosh-cli/releases/tag/v6.4.7)
- cf cli: [7.3.0](https://github.com/cloudfoundry/cli/releases/tag/v7.3.0) [SAN required]
- credhub cli: [2.9.1](https://github.com/cloudfoundry/credhub-cli/releases/tag/2.9.1)
- spruce: [1.29](https://github.com/geofffranks/spruce/releases/tag/v1.29.0)

[SAN required]: https://github.com/cloudfoundry/routing-release/blob/develop/docs/golang1.15-remove-x509ignoreCN%3D0-flag-certificates-now-require-SANs.md