### PR TITLE
Update cf-acceptance-tests to cf-cli 7.4

### DIFF
--- a/cf-acceptance-tests/Dockerfile
+++ b/cf-acceptance-tests/Dockerfile
@@ -17,7 +17,7 @@ ENV GOPATH /go
 ENV PATH /go/bin:/usr/local/go/bin:$PATH
 
 ENV GO_VERSION "1.17"
-ENV CF_CLI_VERSION "7.0.2"
+ENV CF_CLI_VERSION "7.4.0"
 ENV CF_LOG_CACHE_VERSION "2.1.0"
 
 RUN \
@@ -29,7 +29,7 @@ RUN \
 RUN go get github.com/onsi/ginkgo/ginkgo
 
 # Install the cf CLI
-RUN wget -q -O cf.deb "https://cli.run.pivotal.io/stable?release=debian64&version=${CF_CLI_VERSION}&source=github-rel" && \
+RUN wget -q -O cf.deb "https://packages.cloudfoundry.org/stable?release=debian64&version=${CF_CLI_VERSION}&source=github-rel" && \
     dpkg -i cf.deb && \
     rm -f cf.deb
 


### PR DESCRIPTION
We found that double logouts were causing test suite failures for the
autoscaler-acceptance-tests due to the cli version. Version 7.4.0 is
found not to have that issue.

The location for the debian package was retrieved from
https://github.com/cloudfoundry/cli/releases as it later versions were
not being found at the previous location.