### PR TITLE
Build images with GitHub actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/alpine.yml
+++ b/.github/workflows/alpine.yml
@@ -1,0 +1,17 @@
+name: "Image: alpine"
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - "alpine/**"
+      - ".github/workflows/alpine.yml"
+      - ".github/workflows/build-image-base.yml"
+
+jobs:
+  workflows:
+    uses: ./.github/workflows/build-image-base.yml
+    with:
+      image: alpine

--- a/.github/workflows/awscli.yml
+++ b/.github/workflows/awscli.yml
@@ -1,0 +1,18 @@
+name: "Image: awscli"
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - "awscli/**"
+      - ".github/workflows/awscli.yml"
+      - ".github/workflows/build-image-base.yml"
+
+jobs:
+  workflows:
+    uses: ./.github/workflows/build-image-base.yml
+    with:
+      image: awscli
+      has_acceptance_tests: true

--- a/.github/workflows/bosh-cli-v2.yml
+++ b/.github/workflows/bosh-cli-v2.yml
@@ -1,0 +1,18 @@
+name: "Image: bosh-cli-v2"
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - "bosh-cli-v2/**"
+      - ".github/workflows/bosh-cli-v2.yml"
+      - ".github/workflows/build-image-base.yml"
+
+jobs:
+  workflows:
+    uses: ./.github/workflows/build-image-base.yml
+    with:
+      image: bosh-cli-v2
+      has_acceptance_tests: true

--- a/.github/workflows/build-image-base.yml
+++ b/.github/workflows/build-image-base.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           submodules: true
       - name: Log in to the Container registry
-        uses: docker/login-action@42d299face0c5c43a0487c477f595ac9cf22f1a7
+        uses: docker/login-action@49ed152c8eca782a232dede0303416e8f356c37b
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -42,7 +42,7 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v4
         with:
           images: ghcr.io/${{ github.repository }}/${{ inputs.image }}
           tags: |
@@ -56,12 +56,12 @@ jobs:
             org.opencontainers.image.documentation=https://raw.githubusercontent.com/${{ github.repository }}/${{ github.sha }}/${{ inputs.image }}/README.md
             org.opencontainers.image.title=GOV.UK PaaS ${{ inputs.image }}
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
         with:
           platforms: linux/amd64
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: Build for acceptance test
         uses: docker/build-push-action@v3.0.0

--- a/.github/workflows/build-image-base.yml
+++ b/.github/workflows/build-image-base.yml
@@ -1,0 +1,99 @@
+name: Deploy
+on:
+  workflow_call:
+    inputs:
+      image:
+        required: true
+        type: string
+        description: "Image to build"
+      dockerfile:
+        default: Dockerfile
+        type: string
+        description: "Dockerfile name"
+      tag_suffix:
+        type: string
+        description: "Optional suffix for all tags"
+      has_acceptance_tests:
+        default: false
+        type: boolean
+        description: "Specify if acceptance tests are needed for this image"
+      push:
+        default: true
+        type: boolean
+        description: "Disable pushing to ghcr"
+
+env:
+  TEST_TAG: paas-tool:latest
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: true
+      - name: Log in to the Container registry
+        uses: docker/login-action@42d299face0c5c43a0487c477f595ac9cf22f1a7
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ghcr.io/${{ github.repository }}/${{ inputs.image }}
+          tags: |
+            type=sha,format=long,prefix=,suffix=${{ inputs.tag_suffix && format('-{0}', inputs.tag_suffix) }}
+            type=ref,event=branch,suffix=${{ inputs.tag_suffix && format('-{0}', inputs.tag_suffix) }}
+            type=ref,event=pr,suffix=${{ inputs.tag_suffix && format('-{0}', inputs.tag_suffix) }}
+            type=raw,value=latest,enable=${{ endsWith(github.ref, github.event.repository.default_branch) }},suffix=${{ inputs.tag_suffix && format('-{0}', inputs.tag_suffix) }}
+          labels: |
+            org.opencontainers.image.url=https://github.com/${{ github.repository }}/tree/${{ github.sha }}/${{ inputs.image }}
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}/tree/${{ github.sha }}/${{ inputs.image }}
+            org.opencontainers.image.documentation=https://raw.githubusercontent.com/${{ github.repository }}/${{ github.sha }}/${{ inputs.image }}/README.md
+            org.opencontainers.image.title=GOV.UK PaaS ${{ inputs.image }}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: linux/amd64
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Build for acceptance test
+        uses: docker/build-push-action@v3.0.0
+        with:
+          context: ./${{ inputs.image }}
+          file: ./${{ inputs.image }}/${{inputs.dockerfile}}
+          load: true
+          tags: ${{ env.TEST_TAG }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+        if: ${{ inputs.has_acceptance_tests }}
+
+      - name: Set up ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+        if: ${{ inputs.has_acceptance_tests }}
+      - name: Acceptance Tests
+        env:
+          DOCKER_IMAGE: "${{ env.TEST_TAG }}"
+        run: bundle exec rspec ./${{ inputs.image }}/${{ inputs.image }}_spec.rb
+        if: ${{ inputs.has_acceptance_tests }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v3.0.0
+        with:
+          context: ./${{ inputs.image }}
+          platforms: linux/amd64
+          file: ./${{ inputs.image }}/${{inputs.dockerfile}}
+          push: ${{ inputs.push }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/certstrap.yml
+++ b/.github/workflows/certstrap.yml
@@ -1,0 +1,18 @@
+name: "Image: certstrap"
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - "certstrap/**"
+      - ".github/workflows/certstrap.yml"
+      - ".github/workflows/build-image-base.yml"
+
+jobs:
+  workflows:
+    uses: ./.github/workflows/build-image-base.yml
+    with:
+      image: certstrap
+      has_acceptance_tests: true

--- a/.github/workflows/cf-acceptance-tests.yml
+++ b/.github/workflows/cf-acceptance-tests.yml
@@ -1,0 +1,18 @@
+name: "Image: cf-acceptance-tests"
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - "cf-acceptance-tests/**"
+      - ".github/workflows/cf-acceptance-tests.yml"
+      - ".github/workflows/build-image-base.yml"
+
+jobs:
+  workflows:
+    uses: ./.github/workflows/build-image-base.yml
+    with:
+      image: cf-acceptance-tests
+      has_acceptance_tests: true

--- a/.github/workflows/cf-acceptance-tests_ginkgo2.yml
+++ b/.github/workflows/cf-acceptance-tests_ginkgo2.yml
@@ -1,0 +1,20 @@
+name: "Image: cf-acceptance-tests (ginkgo v2)"
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - "cf-acceptance-tests/**"
+      - ".github/workflows/cf-acceptance-tests_ginkgo2.yml"
+      - ".github/workflows/build-image-base.yml"
+
+jobs:
+  workflows:
+    uses: ./.github/workflows/build-image-base.yml
+    with:
+      image: cf-acceptance-tests
+      dockerfile: Dockerfile.ginkgo-v2
+      tag_suffix: ginkgo-v2
+      has_acceptance_tests: true

--- a/.github/workflows/cf-cli.yml
+++ b/.github/workflows/cf-cli.yml
@@ -1,0 +1,18 @@
+name: "Image: cf-cli"
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - "cf-cli/**"
+      - ".github/workflows/cf-cli.yml"
+      - ".github/workflows/build-image-base.yml"
+
+jobs:
+  workflows:
+    uses: ./.github/workflows/build-image-base.yml
+    with:
+      image: cf-cli
+      has_acceptance_tests: true

--- a/.github/workflows/cf-uaac.yml
+++ b/.github/workflows/cf-uaac.yml
@@ -1,0 +1,18 @@
+name: "Image: cf-uaac"
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - "cf-uaac/**"
+      - ".github/workflows/cf-uaac.yml"
+      - ".github/workflows/build-image-base.yml"
+
+jobs:
+  workflows:
+    uses: ./.github/workflows/build-image-base.yml
+    with:
+      image: cf-uaac
+      has_acceptance_tests: true

--- a/.github/workflows/concourse-pool-resource.yml
+++ b/.github/workflows/concourse-pool-resource.yml
@@ -1,0 +1,17 @@
+name: "Image: concourse-pool-resource"
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - "concourse-pool-resource/**"
+      - ".github/workflows/concourse-pool-resource.yml"
+      - ".github/workflows/build-image-base.yml"
+
+jobs:
+  workflows:
+    uses: ./.github/workflows/build-image-base.yml
+    with:
+      image: concourse-pool-resource

--- a/.github/workflows/curl-ssl.yml
+++ b/.github/workflows/curl-ssl.yml
@@ -1,0 +1,18 @@
+name: "Image: curl-ssl"
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - "curl-ssl/**"
+      - ".github/workflows/curl-ssl.yml"
+      - ".github/workflows/build-image-base.yml"
+
+jobs:
+  workflows:
+    uses: ./.github/workflows/build-image-base.yml
+    with:
+      image: curl-ssl
+      has_acceptance_tests: true

--- a/.github/workflows/git-ssh.yml
+++ b/.github/workflows/git-ssh.yml
@@ -1,0 +1,18 @@
+name: "Image: git-ssh"
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - "git-ssh/**"
+      - ".github/workflows/git-ssh.yml"
+      - ".github/workflows/build-image-base.yml"
+
+jobs:
+  workflows:
+    uses: ./.github/workflows/build-image-base.yml
+    with:
+      image: git-ssh
+      has_acceptance_tests: true

--- a/.github/workflows/golang.yml
+++ b/.github/workflows/golang.yml
@@ -1,0 +1,17 @@
+name: "Image: golang"
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - "golang/**"
+      - ".github/workflows/golang.yml"
+      - ".github/workflows/build-image-base.yml"
+
+jobs:
+  workflows:
+    uses: ./.github/workflows/build-image-base.yml
+    with:
+      image: golang

--- a/.github/workflows/json-minify.yml
+++ b/.github/workflows/json-minify.yml
@@ -1,0 +1,18 @@
+name: "Image: json-minify"
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - "json-minify/**"
+      - ".github/workflows/json-minify.yml"
+      - ".github/workflows/build-image-base.yml"
+
+jobs:
+  workflows:
+    uses: ./.github/workflows/build-image-base.yml
+    with:
+      image: json-minify
+      has_acceptance_tests: true

--- a/.github/workflows/middleman.yml
+++ b/.github/workflows/middleman.yml
@@ -1,0 +1,18 @@
+name: "Image: middleman"
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - "middleman/**"
+      - ".github/workflows/middleman.yml"
+      - ".github/workflows/build-image-base.yml"
+
+jobs:
+  workflows:
+    uses: ./.github/workflows/build-image-base.yml
+    with:
+      image: middleman
+      has_acceptance_tests: true

--- a/.github/workflows/node-chromium.yml
+++ b/.github/workflows/node-chromium.yml
@@ -1,0 +1,17 @@
+name: "Image: node-chromium"
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - "node-chromium/**"
+      - ".github/workflows/node-chromium.yml"
+      - ".github/workflows/build-image-base.yml"
+
+jobs:
+  workflows:
+    uses: ./.github/workflows/build-image-base.yml
+    with:
+      image: node-chromium

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -1,0 +1,17 @@
+name: "Image: node"
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - "node/**"
+      - ".github/workflows/node.yml"
+      - ".github/workflows/build-image-base.yml"
+
+jobs:
+  workflows:
+    uses: ./.github/workflows/build-image-base.yml
+    with:
+      image: node

--- a/.github/workflows/olhtbr-metadata-resource.yml
+++ b/.github/workflows/olhtbr-metadata-resource.yml
@@ -1,0 +1,17 @@
+name: "Image: olhtbr-metadata-resource"
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - "olhtbr-metadata-resource/**"
+      - ".github/workflows/olhtbr-metadata-resource.yml"
+      - ".github/workflows/build-image-base.yml"
+
+jobs:
+  workflows:
+    uses: ./.github/workflows/build-image-base.yml
+    with:
+      image: olhtbr-metadata-resource

--- a/.github/workflows/paas-prometheus-exporter.yml
+++ b/.github/workflows/paas-prometheus-exporter.yml
@@ -1,0 +1,18 @@
+name: "Image: paas-prometheus-exporter"
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - "paas-prometheus-exporter/**"
+      - ".github/workflows/paas-prometheus-exporter.yml"
+      - ".github/workflows/build-image-base.yml"
+
+jobs:
+  workflows:
+    uses: ./.github/workflows/build-image-base.yml
+    with:
+      image: paas-prometheus-exporter
+      has_acceptance_tests: true

--- a/.github/workflows/psql.yml
+++ b/.github/workflows/psql.yml
@@ -1,0 +1,18 @@
+name: "Image: psql"
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - "psql/**"
+      - ".github/workflows/psql.yml"
+      - ".github/workflows/build-image-base.yml"
+
+jobs:
+  workflows:
+    uses: ./.github/workflows/build-image-base.yml
+    with:
+      image: psql
+      has_acceptance_tests: true

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -1,0 +1,17 @@
+name: "Image: ruby"
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - "ruby/**"
+      - ".github/workflows/ruby.yml"
+      - ".github/workflows/build-image-base.yml"
+
+jobs:
+  workflows:
+    uses: ./.github/workflows/build-image-base.yml
+    with:
+      image: ruby

--- a/.github/workflows/self-update-pipelines.yml
+++ b/.github/workflows/self-update-pipelines.yml
@@ -1,0 +1,18 @@
+name: "Image: self-update-pipelines"
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - "self-update-pipelines/**"
+      - ".github/workflows/self-update-pipelines.yml"
+      - ".github/workflows/build-image-base.yml"
+
+jobs:
+  workflows:
+    uses: ./.github/workflows/build-image-base.yml
+    with:
+      image: self-update-pipelines
+      has_acceptance_tests: true

--- a/.github/workflows/spruce.yml
+++ b/.github/workflows/spruce.yml
@@ -1,0 +1,18 @@
+name: "Image: spruce"
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - "spruce/**"
+      - ".github/workflows/spruce.yml"
+      - ".github/workflows/build-image-base.yml"
+
+jobs:
+  workflows:
+    uses: ./.github/workflows/build-image-base.yml
+    with:
+      image: spruce
+      has_acceptance_tests: true

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -1,0 +1,18 @@
+name: "Image: terraform"
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - "terraform/**"
+      - ".github/workflows/terraform.yml"
+      - ".github/workflows/build-image-base.yml"
+
+jobs:
+  workflows:
+    uses: ./.github/workflows/build-image-base.yml
+    with:
+      image: terraform
+      has_acceptance_tests: true

--- a/awscli/awscli_spec.rb
+++ b/awscli/awscli_spec.rb
@@ -9,7 +9,7 @@ AWSCLI_VERSION = "1.17.2"
 
 describe "awscli image" do
   before(:all) {
-    set :docker_image, find_image_id('awscli:latest')
+    set :docker_image, find_image_id(ENV['DOCKER_IMAGE'])
   }
 
   def os_version

--- a/bosh-cli-v2/bosh-cli-v2_spec.rb
+++ b/bosh-cli-v2/bosh-cli-v2_spec.rb
@@ -10,7 +10,7 @@ BOSH_ENV_DEPS = "build-essential zlibc zlib1g-dev openssl libxslt1-dev libxml2-d
 
 describe "bosh-cli-v2 image" do
   before(:all) {
-    set :docker_image, find_image_id('bosh-cli-v2:latest')
+    set :docker_image, find_image_id(ENV['DOCKER_IMAGE'])
   }
 
   it "installs required packages" do

--- a/certstrap/certstrap_spec.rb
+++ b/certstrap/certstrap_spec.rb
@@ -8,11 +8,11 @@ CERTSTRAP_PACKAGES = "openssl curl"
 
 describe "certstrap image" do
   before(:all) {
-    set :docker_image, find_image_id('certstrap:latest')
+    set :docker_image, find_image_id(ENV['DOCKER_IMAGE'])
   }
 
   it "installs the right version of Ubuntu Linux" do
-    expect(os_version).to include("Ubuntu 20.04.2")
+    expect(os_version).to include("Ubuntu 20.04")
     expect(os_version).to include("LTS")
   end
 

--- a/cf-acceptance-tests/Dockerfile.ginkgo-v2
+++ b/cf-acceptance-tests/Dockerfile.ginkgo-v2
@@ -1,0 +1,44 @@
+FROM ubuntu:xenial
+
+RUN \
+  apt-get update && \
+  apt-get -y install \
+    build-essential \
+    wget \
+    curl \
+    openssh-client \
+    unzip \
+    python-pip \
+    jq \
+    git fossil mercurial bzr subversion \
+  && rm -rf /var/lib/apt/lists/*
+
+ENV GOPATH /go
+ENV PATH /go/bin:/usr/local/go/bin:$PATH
+
+ENV GO_VERSION "1.17"
+ENV CF_CLI_VERSION "7.4.0"
+ENV CF_LOG_CACHE_VERSION "2.1.0"
+
+RUN \
+  wget https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz -P /tmp && \
+  tar xzvf /tmp/go${GO_VERSION}.linux-amd64.tar.gz -C /usr/local && \
+  mkdir $GOPATH && \
+  rm -rf /tmp/*
+
+RUN go get github.com/onsi/ginkgo/v2 && \
+    go install -mod=mod github.com/onsi/ginkgo/v2/ginkgo@latest
+
+# Install the cf CLI
+RUN wget -q -O cf.deb "https://packages.cloudfoundry.org/stable?release=debian64&version=${CF_CLI_VERSION}&source=github-rel" && \
+    dpkg -i cf.deb && \
+    rm -f cf.deb
+
+# Setup plugins
+ENV CF_PLUGIN_HOME /root/
+
+# Install the log-cache-cli plugin
+RUN cf install-plugin -f "https://github.com/cloudfoundry/log-cache-cli/releases/download/v${CF_LOG_CACHE_VERSION}/log-cache-cf-plugin-linux"
+
+# Install the AWS-CLI
+RUN pip install awscli=="1.14.10"

--- a/cf-acceptance-tests/cf-acceptance-tests_spec.rb
+++ b/cf-acceptance-tests/cf-acceptance-tests_spec.rb
@@ -2,13 +2,13 @@ require 'spec_helper'
 require 'docker'
 require 'serverspec'
 
-GO_VERSION="1.14"
-CF_CLI_VERSION="7.0.2"
+GO_VERSION="1.17"
+CF_CLI_VERSION="7.4.0"
 LOG_CACHE_CLI_VERSION="2.1.0"
 
 describe "cf-acceptance-tests image" do
   before(:all) {
-    set :docker_image, find_image_id('cf-acceptance-tests:latest')
+    set :docker_image, find_image_id(ENV['DOCKER_IMAGE'])
   }
 
   it "has the expected version of Go" do

--- a/cf-cli/cf-cli_spec.rb
+++ b/cf-cli/cf-cli_spec.rb
@@ -8,7 +8,7 @@ SPRUCE_VERSION = "1.27.0"
 
 describe "cf-cli image" do
   before(:all) {
-    set :docker_image, find_image_id('cf-cli:latest')
+    set :docker_image, find_image_id(ENV['DOCKER_IMAGE'])
   }
 
   it "has the expected version of the CF CLI (#{CF_CLI_VERSION})" do

--- a/cf-uaac/cf-uaac_spec.rb
+++ b/cf-uaac/cf-uaac_spec.rb
@@ -6,7 +6,7 @@ UAAC_VERSION="3.2.0"
 
 describe "cf-uaac image" do
   before(:all) {
-    set :docker_image, find_image_id('cf-uaac:latest')
+    set :docker_image, find_image_id(ENV['DOCKER_IMAGE'])
   }
 
   it "has the expected version of uaac" do

--- a/curl-ssl/curl-ssl_spec.rb
+++ b/curl-ssl/curl-ssl_spec.rb
@@ -6,7 +6,7 @@ CURL_SSL_PACKAGES = "jq gettext curl openssl ca-certificates"
 
 describe "curl-ssl image" do
   before(:all) {
-    set :docker_image, find_image_id('curl-ssl:latest')
+    set :docker_image, find_image_id(ENV['DOCKER_IMAGE'])
   }
 
   it "installs the right version of Alpine" do

--- a/git-ssh/git-ssh_spec.rb
+++ b/git-ssh/git-ssh_spec.rb
@@ -8,7 +8,7 @@ OPENSSH_VERSION = "7.2p2"
 
 describe "image" do
   before(:all) {
-    set :docker_image, find_image_id('git-ssh:latest')
+    set :docker_image, find_image_id(ENV['DOCKER_IMAGE'])
   }
 
   it "installs Alpine" do

--- a/json-minify/json-minify_spec.rb
+++ b/json-minify/json-minify_spec.rb
@@ -6,7 +6,7 @@ JSON_MINIFY_VERSION="0.0.2"
 
 describe "json-minify image" do
   before(:all) {
-    set :docker_image, find_image_id('json-minify:latest')
+    set :docker_image, find_image_id(ENV['DOCKER_IMAGE'])
   }
 
   it "has the expected version of the json-minify gem" do

--- a/middleman/middleman_spec.rb
+++ b/middleman/middleman_spec.rb
@@ -4,7 +4,7 @@ require 'serverspec'
 
 describe "middleman image" do
   before(:all) {
-    set :docker_image, find_image_id('middleman:latest')
+    set :docker_image, find_image_id(ENV['DOCKER_IMAGE'])
   }
 
   it "can run middleman" do

--- a/paas-prometheus-exporter/paas-prometheus-exporter_spec.rb
+++ b/paas-prometheus-exporter/paas-prometheus-exporter_spec.rb
@@ -4,7 +4,7 @@ require 'serverspec'
 
 describe "paas-prometheus-exporter" do
   before(:all) {
-    set :docker_image, find_image_id('paas-prometheus-exporter:latest')
+    set :docker_image, find_image_id(ENV['DOCKER_IMAGE'])
   }
 
   let(:version) { '0.0.4' }

--- a/psql/psql_spec.rb
+++ b/psql/psql_spec.rb
@@ -6,7 +6,7 @@ PSQL_PACKAGE = 'postgresql-client'
 
 describe "psql image" do
   before(:all) {
-    set :docker_image, find_image_id('psql:latest')
+    set :docker_image, find_image_id(ENV['DOCKER_IMAGE'])
   }
 
   it "installs the right version of Alpine" do

--- a/self-update-pipelines/self-update-pipelines_spec.rb
+++ b/self-update-pipelines/self-update-pipelines_spec.rb
@@ -7,7 +7,7 @@ AWSCLI_VERSION = "1.17.2"
 
 describe "self-update-pipelines image" do
   before(:all) {
-    set :docker_image, find_image_id('self-update-pipelines:latest')
+    set :docker_image, find_image_id(ENV['DOCKER_IMAGE'])
   }
 
   it "has ruby 2.7 available" do

--- a/spruce/spruce_spec.rb
+++ b/spruce/spruce_spec.rb
@@ -8,7 +8,7 @@ ALPINE_VERSION = "3.13"
 
 describe "spruce image" do
   before(:all) {
-    set :docker_image, find_image_id('spruce:latest')
+    set :docker_image, find_image_id(ENV['DOCKER_IMAGE'])
   }
 
   it "installs the right version of Alpine Linux" do

--- a/terraform/terraform_spec.rb
+++ b/terraform/terraform_spec.rb
@@ -4,7 +4,7 @@ require 'serverspec'
 
 describe "Terraform image" do
   before(:all) {
-    set :docker_image, find_image_id('terraform:latest')
+    set :docker_image, find_image_id(ENV['DOCKER_IMAGE'])
   }
 
   it "installs Alpine" do


### PR DESCRIPTION
Rather than building these on concourse, instead build them with github actions.

This PR currently only pushes the images to ghcr.io. Could be extended to also push to docker hub, although from what I can see a lot of projects are moving away from dockerhub.

Additionally, build a version of cf-acceptance-tests with ginkgo v2 as well as ginkgo v1


Action runs on my fork are visible here: https://github.com/whi-tw/paas-docker-cloudfoundry-tools/actions?query=event%3Apush
Images built on my fork are visible here: https://github.com/whi-tw?tab=packages&repo_name=paas-docker-cloudfoundry-tools