### PR TITLE
Give package write permissions to GITHUB_TOKEN

### DIFF
--- a/.github/workflows/alpine.yml
+++ b/.github/workflows/alpine.yml
@@ -1,5 +1,8 @@
 name: "Image: alpine"
 
+permissions:
+  packages: write
+
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/awscli.yml
+++ b/.github/workflows/awscli.yml
@@ -1,5 +1,8 @@
 name: "Image: awscli"
 
+permissions:
+  packages: write
+
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/bosh-cli-v2.yml
+++ b/.github/workflows/bosh-cli-v2.yml
@@ -1,5 +1,8 @@
 name: "Image: bosh-cli-v2"
 
+permissions:
+  packages: write
+
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/certstrap.yml
+++ b/.github/workflows/certstrap.yml
@@ -1,5 +1,8 @@
 name: "Image: certstrap"
 
+permissions:
+  packages: write
+
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/cf-acceptance-tests.yml
+++ b/.github/workflows/cf-acceptance-tests.yml
@@ -1,5 +1,8 @@
 name: "Image: cf-acceptance-tests"
 
+permissions:
+  packages: write
+
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/cf-acceptance-tests_ginkgo2.yml
+++ b/.github/workflows/cf-acceptance-tests_ginkgo2.yml
@@ -1,6 +1,8 @@
 name: "Image: cf-acceptance-tests (ginkgo v2)"
+
 permissions:
   packages: write
+
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/cf-cli.yml
+++ b/.github/workflows/cf-cli.yml
@@ -1,5 +1,8 @@
 name: "Image: cf-cli"
 
+permissions:
+  packages: write
+
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/cf-uaac.yml
+++ b/.github/workflows/cf-uaac.yml
@@ -1,5 +1,8 @@
 name: "Image: cf-uaac"
 
+permissions:
+  packages: write
+
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/concourse-pool-resource.yml
+++ b/.github/workflows/concourse-pool-resource.yml
@@ -1,5 +1,8 @@
 name: "Image: concourse-pool-resource"
 
+permissions:
+  packages: write
+
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/curl-ssl.yml
+++ b/.github/workflows/curl-ssl.yml
@@ -1,5 +1,8 @@
 name: "Image: curl-ssl"
 
+permissions:
+  packages: write
+
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/git-ssh.yml
+++ b/.github/workflows/git-ssh.yml
@@ -1,5 +1,8 @@
 name: "Image: git-ssh"
 
+permissions:
+  packages: write
+
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/golang.yml
+++ b/.github/workflows/golang.yml
@@ -1,5 +1,8 @@
 name: "Image: golang"
 
+permissions:
+  packages: write
+
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/json-minify.yml
+++ b/.github/workflows/json-minify.yml
@@ -1,5 +1,8 @@
 name: "Image: json-minify"
 
+permissions:
+  packages: write
+
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/middleman.yml
+++ b/.github/workflows/middleman.yml
@@ -1,5 +1,8 @@
 name: "Image: middleman"
 
+permissions:
+  packages: write
+
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/node-chromium.yml
+++ b/.github/workflows/node-chromium.yml
@@ -1,5 +1,8 @@
 name: "Image: node-chromium"
 
+permissions:
+  packages: write
+
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -1,5 +1,8 @@
 name: "Image: node"
 
+permissions:
+  packages: write
+
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/olhtbr-metadata-resource.yml
+++ b/.github/workflows/olhtbr-metadata-resource.yml
@@ -1,5 +1,8 @@
 name: "Image: olhtbr-metadata-resource"
 
+permissions:
+  packages: write
+
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/paas-prometheus-exporter.yml
+++ b/.github/workflows/paas-prometheus-exporter.yml
@@ -1,5 +1,8 @@
 name: "Image: paas-prometheus-exporter"
 
+permissions:
+  packages: write
+
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/psql.yml
+++ b/.github/workflows/psql.yml
@@ -1,5 +1,8 @@
 name: "Image: psql"
 
+permissions:
+  packages: write
+
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -1,5 +1,8 @@
 name: "Image: ruby"
 
+permissions:
+  packages: write
+
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/self-update-pipelines.yml
+++ b/.github/workflows/self-update-pipelines.yml
@@ -1,5 +1,8 @@
 name: "Image: self-update-pipelines"
 
+permissions:
+  packages: write
+
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/spruce.yml
+++ b/.github/workflows/spruce.yml
@@ -1,5 +1,8 @@
 name: "Image: spruce"
 
+permissions:
+  packages: write
+
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -1,5 +1,8 @@
 name: "Image: terraform"
 
+permissions:
+  packages: write
+
 on:
   workflow_dispatch:
   push:


### PR DESCRIPTION
Our GitHub org does not allow us to change the default permissions, so they must be set granularly.

As all the packages are built from separate workflows, there are a lot that need this added to!