### PR TITLE
Fix image naming

### DIFF
--- a/.github/workflows/build-image-base.yml
+++ b/.github/workflows/build-image-base.yml
@@ -44,7 +44,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v4
         with:
-          images: ghcr.io/${{ github.repository }}/${{ inputs.image }}
+          images: ghcr.io/paas/${{ inputs.image }}
           tags: |
             type=sha,format=long,prefix=,suffix=${{ inputs.tag_suffix && format('-{0}', inputs.tag_suffix) }}
             type=ref,event=branch,suffix=${{ inputs.tag_suffix && format('-{0}', inputs.tag_suffix) }}


### PR DESCRIPTION
Our existing images use 'ghcr.io/alphagov/paas/${NAME}'. It seems like this is a gds standard, so let's use that instead.
