### PR TITLE
Use the CI user secrets

### DIFF
--- a/.github/workflows/alpine.yml
+++ b/.github/workflows/alpine.yml
@@ -1,8 +1,5 @@
 name: "Image: alpine"
 
-permissions:
-  packages: write
-
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/awscli.yml
+++ b/.github/workflows/awscli.yml
@@ -1,8 +1,5 @@
 name: "Image: awscli"
 
-permissions:
-  packages: write
-
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/bosh-cli-v2.yml
+++ b/.github/workflows/bosh-cli-v2.yml
@@ -1,8 +1,5 @@
 name: "Image: bosh-cli-v2"
 
-permissions:
-  packages: write
-
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/build-image-base.yml
+++ b/.github/workflows/build-image-base.yml
@@ -37,8 +37,8 @@ jobs:
         uses: docker/login-action@49ed152c8eca782a232dede0303416e8f356c37b
         with:
           registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: ${{ secrets.CI_USER_USERNAME }}
+          password: ${{ secrets.CI_USER_CONTAINER_REGISTRY_TOKEN }}
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta

--- a/.github/workflows/certstrap.yml
+++ b/.github/workflows/certstrap.yml
@@ -1,8 +1,5 @@
 name: "Image: certstrap"
 
-permissions:
-  packages: write
-
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/cf-acceptance-tests.yml
+++ b/.github/workflows/cf-acceptance-tests.yml
@@ -1,8 +1,5 @@
 name: "Image: cf-acceptance-tests"
 
-permissions:
-  packages: write
-
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/cf-acceptance-tests_ginkgo2.yml
+++ b/.github/workflows/cf-acceptance-tests_ginkgo2.yml
@@ -1,8 +1,5 @@
 name: "Image: cf-acceptance-tests (ginkgo v2)"
 
-permissions:
-  packages: write
-
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/cf-acceptance-tests_ginkgo2.yml
+++ b/.github/workflows/cf-acceptance-tests_ginkgo2.yml
@@ -1,5 +1,4 @@
 name: "Image: cf-acceptance-tests (ginkgo v2)"
-
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/cf-cli.yml
+++ b/.github/workflows/cf-cli.yml
@@ -1,8 +1,5 @@
 name: "Image: cf-cli"
 
-permissions:
-  packages: write
-
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/cf-uaac.yml
+++ b/.github/workflows/cf-uaac.yml
@@ -1,8 +1,5 @@
 name: "Image: cf-uaac"
 
-permissions:
-  packages: write
-
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/concourse-pool-resource.yml
+++ b/.github/workflows/concourse-pool-resource.yml
@@ -1,8 +1,5 @@
 name: "Image: concourse-pool-resource"
 
-permissions:
-  packages: write
-
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/curl-ssl.yml
+++ b/.github/workflows/curl-ssl.yml
@@ -1,8 +1,5 @@
 name: "Image: curl-ssl"
 
-permissions:
-  packages: write
-
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/git-ssh.yml
+++ b/.github/workflows/git-ssh.yml
@@ -1,8 +1,5 @@
 name: "Image: git-ssh"
 
-permissions:
-  packages: write
-
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/golang.yml
+++ b/.github/workflows/golang.yml
@@ -1,8 +1,5 @@
 name: "Image: golang"
 
-permissions:
-  packages: write
-
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/json-minify.yml
+++ b/.github/workflows/json-minify.yml
@@ -1,8 +1,5 @@
 name: "Image: json-minify"
 
-permissions:
-  packages: write
-
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/middleman.yml
+++ b/.github/workflows/middleman.yml
@@ -1,8 +1,5 @@
 name: "Image: middleman"
 
-permissions:
-  packages: write
-
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/node-chromium.yml
+++ b/.github/workflows/node-chromium.yml
@@ -1,8 +1,5 @@
 name: "Image: node-chromium"
 
-permissions:
-  packages: write
-
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -1,8 +1,5 @@
 name: "Image: node"
 
-permissions:
-  packages: write
-
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/olhtbr-metadata-resource.yml
+++ b/.github/workflows/olhtbr-metadata-resource.yml
@@ -1,8 +1,5 @@
 name: "Image: olhtbr-metadata-resource"
 
-permissions:
-  packages: write
-
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/paas-prometheus-exporter.yml
+++ b/.github/workflows/paas-prometheus-exporter.yml
@@ -1,8 +1,5 @@
 name: "Image: paas-prometheus-exporter"
 
-permissions:
-  packages: write
-
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/psql.yml
+++ b/.github/workflows/psql.yml
@@ -1,8 +1,5 @@
 name: "Image: psql"
 
-permissions:
-  packages: write
-
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -1,8 +1,5 @@
 name: "Image: ruby"
 
-permissions:
-  packages: write
-
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/self-update-pipelines.yml
+++ b/.github/workflows/self-update-pipelines.yml
@@ -1,8 +1,5 @@
 name: "Image: self-update-pipelines"
 
-permissions:
-  packages: write
-
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/spruce.yml
+++ b/.github/workflows/spruce.yml
@@ -1,8 +1,5 @@
 name: "Image: spruce"
 
-permissions:
-  packages: write
-
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -1,8 +1,5 @@
 name: "Image: terraform"
 
-permissions:
-  packages: write
-
 on:
   workflow_dispatch:
   push:

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+SHELL:= /usr/bin/env bash
+PAAS_PASSWORD_STORE_DIR := ${HOME}/.paas-pass
+
+
+.PHONY: upload-ghcr-secrets
+upload-ghcr-secrets: export PASSWORD_STORE_DIR = $(PAAS_PASSWORD_STORE_DIR)
+upload-ghcr-secrets:
+	gh secret set CI_USER_USERNAME < <(pass github.com/ci-user-username)
+	gh secret set CI_USER_CONTAINER_REGISTRY_TOKEN < <(pass github.com/ci-user-container-registry-token)


### PR DESCRIPTION
As we're no longer pushing to a repo-scoped image, the automatically
provided GITHUB_TOKEN is no longer useful for pushing.

Instead, use the existing CI_USER_* secrets from paas-pass.

If these need to be re-uploaded (ie. after rotation), this can be done
via the make task 'upload-ghcr-secrets'
