### PR TITLE
Allow passing secrets to the reusable workflow

### DIFF
--- a/.github/workflows/alpine.yml
+++ b/.github/workflows/alpine.yml
@@ -15,3 +15,4 @@ jobs:
     uses: ./.github/workflows/build-image-base.yml
     with:
       image: alpine
+    secrets: inherit

--- a/.github/workflows/awscli.yml
+++ b/.github/workflows/awscli.yml
@@ -16,3 +16,4 @@ jobs:
     with:
       image: awscli
       has_acceptance_tests: true
+    secrets: inherit

--- a/.github/workflows/bosh-cli-v2.yml
+++ b/.github/workflows/bosh-cli-v2.yml
@@ -16,3 +16,4 @@ jobs:
     with:
       image: bosh-cli-v2
       has_acceptance_tests: true
+    secrets: inherit

--- a/.github/workflows/build-image-base.yml
+++ b/.github/workflows/build-image-base.yml
@@ -21,6 +21,11 @@ on:
         default: true
         type: boolean
         description: "Disable pushing to ghcr"
+    secrets:
+      CI_USER_USERNAME:
+        required: true
+      CI_USER_CONTAINER_REGISTRY_TOKEN:
+        required: true
 
 env:
   TEST_TAG: paas-tool:latest

--- a/.github/workflows/certstrap.yml
+++ b/.github/workflows/certstrap.yml
@@ -16,3 +16,4 @@ jobs:
     with:
       image: certstrap
       has_acceptance_tests: true
+    secrets: inherit

--- a/.github/workflows/cf-acceptance-tests.yml
+++ b/.github/workflows/cf-acceptance-tests.yml
@@ -16,3 +16,4 @@ jobs:
     with:
       image: cf-acceptance-tests
       has_acceptance_tests: true
+    secrets: inherit

--- a/.github/workflows/cf-acceptance-tests_ginkgo2.yml
+++ b/.github/workflows/cf-acceptance-tests_ginkgo2.yml
@@ -17,3 +17,4 @@ jobs:
       dockerfile: Dockerfile.ginkgo-v2
       tag_suffix: ginkgo-v2
       has_acceptance_tests: true
+    secrets: inherit

--- a/.github/workflows/cf-cli.yml
+++ b/.github/workflows/cf-cli.yml
@@ -16,3 +16,4 @@ jobs:
     with:
       image: cf-cli
       has_acceptance_tests: true
+    secrets: inherit

--- a/.github/workflows/cf-uaac.yml
+++ b/.github/workflows/cf-uaac.yml
@@ -16,3 +16,4 @@ jobs:
     with:
       image: cf-uaac
       has_acceptance_tests: true
+    secrets: inherit

--- a/.github/workflows/concourse-pool-resource.yml
+++ b/.github/workflows/concourse-pool-resource.yml
@@ -15,3 +15,4 @@ jobs:
     uses: ./.github/workflows/build-image-base.yml
     with:
       image: concourse-pool-resource
+    secrets: inherit

--- a/.github/workflows/curl-ssl.yml
+++ b/.github/workflows/curl-ssl.yml
@@ -16,3 +16,4 @@ jobs:
     with:
       image: curl-ssl
       has_acceptance_tests: true
+    secrets: inherit

--- a/.github/workflows/git-ssh.yml
+++ b/.github/workflows/git-ssh.yml
@@ -16,3 +16,4 @@ jobs:
     with:
       image: git-ssh
       has_acceptance_tests: true
+    secrets: inherit

--- a/.github/workflows/golang.yml
+++ b/.github/workflows/golang.yml
@@ -15,3 +15,4 @@ jobs:
     uses: ./.github/workflows/build-image-base.yml
     with:
       image: golang
+    secrets: inherit

--- a/.github/workflows/json-minify.yml
+++ b/.github/workflows/json-minify.yml
@@ -16,3 +16,4 @@ jobs:
     with:
       image: json-minify
       has_acceptance_tests: true
+    secrets: inherit

--- a/.github/workflows/middleman.yml
+++ b/.github/workflows/middleman.yml
@@ -16,3 +16,4 @@ jobs:
     with:
       image: middleman
       has_acceptance_tests: true
+    secrets: inherit

--- a/.github/workflows/node-chromium.yml
+++ b/.github/workflows/node-chromium.yml
@@ -15,3 +15,4 @@ jobs:
     uses: ./.github/workflows/build-image-base.yml
     with:
       image: node-chromium
+    secrets: inherit

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -15,3 +15,4 @@ jobs:
     uses: ./.github/workflows/build-image-base.yml
     with:
       image: node
+    secrets: inherit

--- a/.github/workflows/olhtbr-metadata-resource.yml
+++ b/.github/workflows/olhtbr-metadata-resource.yml
@@ -15,3 +15,4 @@ jobs:
     uses: ./.github/workflows/build-image-base.yml
     with:
       image: olhtbr-metadata-resource
+    secrets: inherit

--- a/.github/workflows/paas-prometheus-exporter.yml
+++ b/.github/workflows/paas-prometheus-exporter.yml
@@ -16,3 +16,4 @@ jobs:
     with:
       image: paas-prometheus-exporter
       has_acceptance_tests: true
+    secrets: inherit

--- a/.github/workflows/psql.yml
+++ b/.github/workflows/psql.yml
@@ -16,3 +16,4 @@ jobs:
     with:
       image: psql
       has_acceptance_tests: true
+    secrets: inherit

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -15,3 +15,4 @@ jobs:
     uses: ./.github/workflows/build-image-base.yml
     with:
       image: ruby
+    secrets: inherit

--- a/.github/workflows/self-update-pipelines.yml
+++ b/.github/workflows/self-update-pipelines.yml
@@ -16,3 +16,4 @@ jobs:
     with:
       image: self-update-pipelines
       has_acceptance_tests: true
+    secrets: inherit

--- a/.github/workflows/spruce.yml
+++ b/.github/workflows/spruce.yml
@@ -16,3 +16,4 @@ jobs:
     with:
       image: spruce
       has_acceptance_tests: true
+    secrets: inherit

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -16,3 +16,4 @@ jobs:
     with:
       image: terraform
       has_acceptance_tests: true
+    secrets: inherit


### PR DESCRIPTION
Github actions is a bit arcane in some ways.

By default, secrets aren't passed directly to reusable workflows,
because otherwise you could end up passing secrets to a bad actor
if using a workflow from a third party.

Normally, we would have to specify the specific secrets that need to be
passed to the reusable workflow, but as it's a local one, we can just
specify that it inherits the provided secrets.

Note: I'm not sure why the GITHUB_TOKEN automatic secret doesn't cause
these same issues!
