### PR TITLE
Push to dockerhub as well as ghcr.io

### DIFF
--- a/.github/workflows/build-image-base.yml
+++ b/.github/workflows/build-image-base.yml
@@ -20,12 +20,25 @@ on:
       push:
         default: true
         type: boolean
-        description: "Disable pushing to ghcr"
+        description: "Push to registries"
+      platforms:
+        default: linux/amd64
+        type: string
+        description: "Platforms to build for"
+
     secrets:
       CI_USER_USERNAME:
         required: true
+        description: Username for logging into ghcr.io
       CI_USER_CONTAINER_REGISTRY_TOKEN:
         required: true
+        description: Token for logging into ghcr.io
+      DOCKERHUB_USERNAME:
+        required: true
+        description: Username for logging into dockerhub
+      DOCKERHUB_PASSWORD:
+        required: true
+        description: Password for logging into dockerhub
 
 env:
   TEST_TAG: paas-tool:latest
@@ -38,15 +51,15 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: true
-      - name: Log in to the Container registry
+      - name: Log in to ghcr.io Container registry
         uses: docker/login-action@49ed152c8eca782a232dede0303416e8f356c37b
         with:
           registry: ghcr.io
           username: ${{ secrets.CI_USER_USERNAME }}
           password: ${{ secrets.CI_USER_CONTAINER_REGISTRY_TOKEN }}
 
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
+      - name: Extract metadata (tags, labels) for ghcr
+        id: meta-ghcr
         uses: docker/metadata-action@v4
         with:
           images: ghcr.io/alphagov/paas/${{ inputs.image }}
@@ -60,10 +73,26 @@ jobs:
             org.opencontainers.image.source=https://github.com/${{ github.repository }}/tree/${{ github.sha }}/${{ inputs.image }}
             org.opencontainers.image.documentation=https://raw.githubusercontent.com/${{ github.repository }}/${{ github.sha }}/${{ inputs.image }}/README.md
             org.opencontainers.image.title=GOV.UK PaaS ${{ inputs.image }}
+      - name: Extract metadata (tags, labels) for docker hub
+        id: meta-dockerhub
+        uses: docker/metadata-action@v4
+        with:
+          images: governmentpaas/${{ inputs.image }}
+          tags: |
+            type=sha,format=long,prefix=,suffix=${{ inputs.tag_suffix && format('-{0}', inputs.tag_suffix) }}
+            type=ref,event=branch,suffix=${{ inputs.tag_suffix && format('-{0}', inputs.tag_suffix) }}
+            type=ref,event=pr,suffix=${{ inputs.tag_suffix && format('-{0}', inputs.tag_suffix) }}
+            type=raw,value=latest,enable=${{ endsWith(github.ref, github.event.repository.default_branch) }},suffix=${{ inputs.tag_suffix && format('-{0}', inputs.tag_suffix) }}
+          labels: |
+            org.opencontainers.image.url=https://github.com/${{ github.repository }}/tree/${{ github.sha }}/${{ inputs.image }}
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}/tree/${{ github.sha }}/${{ inputs.image }}
+            org.opencontainers.image.documentation=https://raw.githubusercontent.com/${{ github.repository }}/${{ github.sha }}/${{ inputs.image }}/README.md
+            org.opencontainers.image.title=GOV.UK PaaS ${{ inputs.image }}
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
         with:
-          platforms: linux/amd64
+          platforms: ${{ inputs.platforms }}
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v2
@@ -75,9 +104,10 @@ jobs:
           file: ./${{ inputs.image }}/${{inputs.dockerfile}}
           load: true
           tags: ${{ env.TEST_TAG }}
-          labels: ${{ steps.meta.outputs.labels }}
+          labels: ${{ steps.meta-ghcr.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          platforms: ${{ inputs.platforms }}
         if: ${{ inputs.has_acceptance_tests }}
 
       - name: Set up ruby
@@ -91,14 +121,32 @@ jobs:
         run: bundle exec rspec ./${{ inputs.image }}/${{ inputs.image }}_spec.rb
         if: ${{ inputs.has_acceptance_tests }}
 
-      - name: Build and push
+      - name: Build and push to ghcr
         uses: docker/build-push-action@v3.0.0
         with:
           context: ./${{ inputs.image }}
-          platforms: linux/amd64
+          platforms: ${{ inputs.platforms }}
           file: ./${{ inputs.image }}/${{inputs.dockerfile}}
           push: ${{ inputs.push }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          tags: ${{ steps.meta-ghcr.outputs.tags }}
+          labels: ${{ steps.meta-ghcr.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Log in to docker hub Container registry
+        uses: docker/login-action@49ed152c8eca782a232dede0303416e8f356c37b
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+      - name: Build and push to docker hub
+        uses: docker/build-push-action@v3.0.0
+        with:
+          context: ./${{ inputs.image }}
+          platforms: ${{ inputs.platforms }}
+          file: ./${{ inputs.image }}/${{inputs.dockerfile}}
+          push: ${{ inputs.push }}
+          tags: ${{ steps.meta-dockerhub.outputs.tags }}
+          labels: ${{ steps.meta-dockerhub.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/Makefile
+++ b/Makefile
@@ -7,3 +7,5 @@ upload-ghcr-secrets: export PASSWORD_STORE_DIR = $(PAAS_PASSWORD_STORE_DIR)
 upload-ghcr-secrets:
 	gh secret set CI_USER_USERNAME < <(pass github.com/ci-user-username)
 	gh secret set CI_USER_CONTAINER_REGISTRY_TOKEN < <(pass github.com/ci-user-container-registry-token)
+	gh secret set DOCKERHUB_USERNAME < <(pass dockerhub/ci/id)
+	gh secret set DOCKERHUB_PASSWORD < <(pass dockerhub/ci/password)


### PR DESCRIPTION
Additionally push to docker hub.

Also, a couple of minor changes to inputs, allowing the platform to be specified per-image for spicy M1 action.