### PR TITLE
[#182295946] Build curl-ssl using our alpine base image

### DIFF
--- a/curl-ssl/Dockerfile
+++ b/curl-ssl/Dockerfile
@@ -1,5 +1,6 @@
-FROM alpine:3.13
+FROM ghcr.io/alphagov/paas/alpine:main
 
-ENV PACKAGES "jq gettext curl openssl ca-certificates"
-
-RUN apk add --no-cache $PACKAGES
+RUN apk add --no-cache \
+    jq=1.6-r1 \
+    gettext=0.21-r2 \
+    curl=7.83.1-r1


### PR DESCRIPTION
## What

Build curl-ssl with our alpine image as a base.

This takes pressure off of #233, as it depends on a image that that PR is introducing

## How to review

Describe the steps required to test the changes.

## Before Merging

* Merge #233
* Rebase against `main`, force push and check the pipelines run

## After Merging

* Move on to #236
