### PR TITLE
182427769 - Upgrade OpenSSL alpine base image

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:3.16
 
 RUN apk add --no-cache \
-        openssl=1.1.1o-r0 \
+        openssl=1.1.1q-r0 \
         ca-certificates=20211220-r0


### PR DESCRIPTION
Description:
- Older OpenSSL image isn't present in the Alpine repository so we have to bump up to ensure the GitHub actions pass