### PR TITLE
Upgrade cf acceptance test base image to bionic

### DIFF
--- a/cf-acceptance-tests/Dockerfile
+++ b/cf-acceptance-tests/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:xenial
+FROM ubuntu:bionic
 
 RUN \
   apt-get update && \


### PR DESCRIPTION


## What
Upgrade cf acceptance test base image to bionic

This is one of the last places xenial was used. Broke our billing acceptance tests as postgres is no longer providing xenial apt packages.

## How to review

- Check CI
- Deploy in dev env
