### PR TITLE
182889631 Upgrade brokered autoscaler to V8

### DIFF
--- a/cf-acceptance-tests/Dockerfile
+++ b/cf-acceptance-tests/Dockerfile
@@ -16,7 +16,7 @@ RUN apt update \
 ENV GOPATH /go
 ENV PATH /go/bin:/usr/local/go/bin:$PATH
 
-ENV GO_VERSION "1.18"
+ENV GO_VERSION "1.19"
 ENV CF_CLI_VERSION "7.4.0"
 ENV CF_LOG_CACHE_VERSION "2.1.0"
 


### PR DESCRIPTION
Description:
- Since app-autoscaler is upgraded to 8.0.0 (see https://github.com/alphagov/paas-cf/pull/2994) the tests need Go 1.19 to run

## What

Describe what you have changed and why.

## How to review

See latest build on dev02 using pr-251 for cf-acceptance-tests.
