### PR TITLE
set apt to be noninteractive

### DIFF
--- a/ubuntu/Dockerfile
+++ b/ubuntu/Dockerfile
@@ -1,5 +1,6 @@
 FROM ubuntu:bionic
 
+ENV DEBIAN_FRONTEND=noninteractive
 RUN apt update \
     && apt install -y \
         openssl \


### PR DESCRIPTION
## What

export `DEBIAN_FRONTEND=noninteractive` in the base image, so that apt behaves as expected in child images

## How to review

- Sense check
