### PR TITLE
constrain versions used by `apk` less restrictively

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:3.16
 
 RUN apk add --no-cache \
-        openssl=1.1.1q-r0 \
-        ca-certificates~=20220614
+        openssl~1.1 \
+        ca-certificates>=20220614

--- a/awscli/Dockerfile
+++ b/awscli/Dockerfile
@@ -3,9 +3,9 @@ FROM ghcr.io/alphagov/paas/curl-ssl:main
 ENV AWSCLI_VERSION "1.18.140"
 
 RUN apk add --no-cache \
-        groff=1.22.4-r1 \
-        less=590-r0 \
-        python3=3.10.5-r0 \
-        py3-pip=22.1.1-r0 \
+        groff~1.22.4-r1 \
+        less>=590-r0 \
+        python3~3.10 \
+        py3-pip~22 \
     && pip3 install \
         awscli==$AWSCLI_VERSION

--- a/curl-ssl/Dockerfile
+++ b/curl-ssl/Dockerfile
@@ -1,6 +1,6 @@
 FROM ghcr.io/alphagov/paas/alpine:main
 
 RUN apk add --no-cache \
-    jq=1.6-r1 \
-    gettext=0.21-r2 \
-    curl=7.83.1-r3
+    jq~1 \
+    gettext~0.21 \
+    curl~7

--- a/git-ssh/Dockerfile
+++ b/git-ssh/Dockerfile
@@ -1,11 +1,11 @@
 FROM ghcr.io/alphagov/paas/alpine:main
 
 RUN apk add --no-cache \
-        git=2.36.3-r0 \
-        curl=7.83.1-r3 \
-        openssh-client-default=9.0_p1-r2 \
-        gnupg=2.2.35-r4 \
-        bash=5.1.16-r2
+        git~2 \
+        curl~7 \
+        openssh-client-default~9 \
+        gnupg~2.2 \
+        bash~5.1
 
 RUN mkdir -p /root/.ssh \
     && git config --global user.email "git-ssh@governmentpaas.docker"  \

--- a/psql/Dockerfile
+++ b/psql/Dockerfile
@@ -3,4 +3,4 @@ FROM ghcr.io/alphagov/paas/alpine:main
 ENV PACKAGES "postgresql-client"
 
 RUN apk add --no-cache \
-        postgresql14-client=14.5-r0
+        postgresql14-client~14

--- a/spruce/Dockerfile
+++ b/spruce/Dockerfile
@@ -3,7 +3,7 @@ FROM ghcr.io/alphagov/paas/alpine:main
 ENV SPRUCE_VERSION 1.27.0
 
 RUN apk add --no-cache \
-        wget=1.21.3-r0 \
+        wget~1 \
     && wget https://github.com/geofffranks/spruce/releases/download/v${SPRUCE_VERSION}/spruce-linux-amd64 \
     && chmod +x spruce-linux-amd64 \
     && mv spruce-linux-amd64 /usr/local/bin/spruce \


### PR DESCRIPTION
## What

Previously we had 'hard' version pinning for `apk` installed packages, which means that as soon as those versions fall off the repositories, our builds started failing.

Instead of this, I have changed the pinning so that it will get either the latest version that matches a certain semver tilde restriction (these can be visualised with the [Online Semver checker](https://jubianchi.github.io/semver-check/#/constraint/~7)).

## How to review

Check that the constraints I have added make sense
