### PR TITLE
Use Ruby 3.1 across the board

### DIFF
--- a/bosh-cli-v2/Dockerfile
+++ b/bosh-cli-v2/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.7-slim-buster
+FROM ruby:3.1-slim-buster
 
 ENV BOSH_CLI_VERSION 6.4.4
 ENV BOSH_CLI_SUM c944dd694e5470686995c2365ac60c9ef06f655cab51994f7fefed4c89e764fb

--- a/bosh-cli-v2/bosh-cli-v2_spec.rb
+++ b/bosh-cli-v2/bosh-cli-v2_spec.rb
@@ -82,10 +82,10 @@ describe "bosh-cli-v2 image" do
     end
   end
 
-  it "has ruby 2.7 available" do
+  it "has ruby 3.1 available" do
     cmd = command("ruby -v")
     expect(cmd.exit_status).to eq(0)
-    expect(cmd.stdout).to match(/^ruby 2.7/)
+    expect(cmd.stdout).to match(/^ruby 3.1/)
   end
 
   it "contains the compiled CPI packages" do

--- a/cf-cli/cf-cli_spec.rb
+++ b/cf-cli/cf-cli_spec.rb
@@ -46,10 +46,10 @@ describe "cf-cli image" do
     expect(cmd.exit_status).to eq(0)
   end
 
-  it "has ruby 2.7 available" do
+  it "has ruby 3.1 available" do
     cmd = command("ruby -v")
     expect(cmd.exit_status).to eq(0)
-    expect(cmd.stdout).to match(/^ruby 2.7/)
+    expect(cmd.stdout).to match(/^ruby 3.1/)
   end
 
   it "has ruby json gem available" do

--- a/ruby-base/Dockerfile
+++ b/ruby-base/Dockerfile
@@ -1,1 +1,1 @@
-FROM ruby:2.7-alpine3.16
+FROM ruby:3.1-alpine3.16

--- a/ruby/Dockerfile
+++ b/ruby/Dockerfile
@@ -1,1 +1,1 @@
-FROM ruby:2.7-slim
+FROM ruby:3.1-slim

--- a/self-update-pipelines/Dockerfile
+++ b/self-update-pipelines/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.7-slim-buster
+FROM ruby:3.1-slim-buster
 
 ENV AWSCLI_VERSION "1.17.2"
 ENV PACKAGES make python-setuptools python-pip groff less curl

--- a/self-update-pipelines/self-update-pipelines_spec.rb
+++ b/self-update-pipelines/self-update-pipelines_spec.rb
@@ -10,10 +10,10 @@ describe "self-update-pipelines image" do
     set :docker_image, find_image_id(ENV['DOCKER_IMAGE'])
   }
 
-  it "has ruby 2.7 available" do
+  it "has ruby 3,1 available" do
     expect(
       command("ruby -v").stdout
-    ).to match(/ruby 2\.7/)
+    ).to match(/ruby 3\.1/)
   end
 
   it "has curl available" do


### PR DESCRIPTION
## What

Wherever we use Ruby in a Docker image, upgrades to Ruby 3.1

## How to review

Check the images are built successfully, and tests pass.

N.B. because some images (such as `cf-cli`) reference `ghcr.io/alphagov/paas/ruby-base:main`, they won't _actually_ get Ruby 3.1 until this PR is merged
