### PR TITLE
updated awscli version to get taglist metadata for kipper

### DIFF
--- a/kipper/Dockerfile
+++ b/kipper/Dockerfile
@@ -1,6 +1,6 @@
 FROM ghcr.io/alphagov/paas/bosh-cli-v2:main
 
-ENV AWSCLI_VERSION "1.18.140"
+ENV AWSCLI_VERSION "1.27.90"
 
 RUN apt-get update && apt-get install -y \
   python3 \


### PR DESCRIPTION
## What

bumped the awscli version to 1.27.90 (latest as of now) because the previous version doesn't include the taglist metatdata in describe-db-instances that I need for kipper  

## How to review

look at the code
