### PR TITLE
18504128 - Upgrade CLI versions in paas-docker-cloudfoundry-tools

### DIFF
--- a/awscli/Dockerfile
+++ b/awscli/Dockerfile
@@ -1,6 +1,6 @@
 FROM ghcr.io/alphagov/paas/curl-ssl:main
 
-ENV AWSCLI_VERSION "1.18.140"
+ENV AWSCLI_VERSION "1.19.112"
 
 RUN apk add --no-cache \
         groff~1.22.4-r1 \

--- a/awscli/awscli_spec.rb
+++ b/awscli/awscli_spec.rb
@@ -5,7 +5,7 @@ require 'serverspec'
 AWSCLI_PACKAGES = "curl openssl ca-certificates less"
 
 AWSCLI_BIN = "/usr/bin/aws"
-AWSCLI_VERSION = "1.17.2"
+AWSCLI_VERSION = "1.19.112"
 
 describe "awscli image" do
   before(:all) {

--- a/bosh-cli-v2/Dockerfile
+++ b/bosh-cli-v2/Dockerfile
@@ -1,7 +1,7 @@
 FROM ruby:3.1-slim-buster
 
-ENV BOSH_CLI_VERSION 6.4.4
-ENV BOSH_CLI_SUM c944dd694e5470686995c2365ac60c9ef06f655cab51994f7fefed4c89e764fb
+ENV BOSH_CLI_VERSION 6.4.17
+ENV BOSH_CLI_SUM d0917d3ad0ff544a4c69a7986e710fe48e8cb2207717f77db31905d639e28c18
 ENV BOSH_CLI_FILENAME bosh-cli-${BOSH_CLI_VERSION}-linux-amd64
 
 ENV DEBIAN_PACKAGES "ca-certificates wget git openssh-client file jq"
@@ -10,8 +10,8 @@ ENV DEBIAN_PACKAGES "ca-certificates wget git openssh-client file jq"
 ENV BOSH_ENV_DEPS "build-essential zlibc zlib1g-dev openssl libxslt1-dev \
   libxml2-dev libssl-dev libreadline7 libreadline-dev libyaml-dev libsqlite3-dev sqlite3"
 
-ENV BOSH_AWS_CPI_URL https://bosh.io/d/github.com/cloudfoundry/bosh-aws-cpi-release?v=87
-ENV BOSH_AWS_CPI_CHECKSUM a920cd1bdead3d6167273e763912becca2225ba6
+ENV BOSH_AWS_CPI_URL https://bosh.io/d/github.com/cloudfoundry/bosh-aws-cpi-release?v=97
+ENV BOSH_AWS_CPI_CHECKSUM b6aa84bc178e5cc99faa55a89943214c33488d5f
 
 RUN apt-get update \
   && apt-get -y upgrade \
@@ -28,8 +28,8 @@ COPY bosh_init_cache /tmp/bosh_init_cache/
 RUN /tmp/bosh_init_cache/seed_bosh_init_cache.sh && \
     rm -rf /tmp/bosh_init_cache
 
-ENV CREDHUB_CLI_VERSION 2.9.0
-ENV CREDHUB_CLI_SUM f260e926099f9eb9474ab2239851e391bfd0fd1354a52891f3c834cea1630e8a
+ENV CREDHUB_CLI_VERSION 2.9.14
+ENV CREDHUB_CLI_SUM 79cf9100fd4e0c9024752b097911406bc73d387c985c72330598ba445eb92bfb
 ENV CREDHUB_CLI_FILENAME credhub-linux-${CREDHUB_CLI_VERSION}.tgz
 
 RUN wget -nv https://github.com/cloudfoundry-incubator/credhub-cli/releases/download/${CREDHUB_CLI_VERSION}/${CREDHUB_CLI_FILENAME} \
@@ -38,8 +38,8 @@ RUN wget -nv https://github.com/cloudfoundry-incubator/credhub-cli/releases/down
   && chmod +x credhub \
   && mv credhub /usr/local/bin/credhub
 
-ENV YQ_VERSION 4.9.6
-ENV YQ_SUM a1cfa39a9538e27f11066aa5659b32f9beae1eea93369d395bf45bcfc8a181dc
+ENV YQ_VERSION 4.26.1
+ENV YQ_SUM 9e35b817e7cdc358c1fcd8498f3872db169c3303b61645cc1faf972990f37582
 ENV YQ_FILENAME yq_linux_amd64
 
 RUN wget -nv https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/${YQ_FILENAME} \

--- a/certstrap/Dockerfile
+++ b/certstrap/Dockerfile
@@ -1,8 +1,8 @@
 FROM ghcr.io/alphagov/paas/ubuntu:main
 
-ENV GIT_COMMIT bd8b02aa8c1b81bc5cfc070722a1a894a348f00a
-ENV CERTSTRAP_VERSION 1.2.0
+ENV GIT_COMMIT 1377eabdd8242bc353dcebf879a3b077413036c2
+ENV CERTSTRAP_VERSION 1.3.0
 
-RUN wget -O certstrap https://github.com/square/certstrap/releases/download/v${CERTSTRAP_VERSION}/certstrap-${CERTSTRAP_VERSION}-linux-amd64 \
+RUN wget -O certstrap https://github.com/square/certstrap/releases/download/v${CERTSTRAP_VERSION}/certstrap-linux-amd64 \
     && chmod +x certstrap \
     && cp certstrap /usr/local/bin/

--- a/cf-acceptance-tests/Dockerfile
+++ b/cf-acceptance-tests/Dockerfile
@@ -40,4 +40,4 @@ ENV CF_PLUGIN_HOME /root/
 RUN cf install-plugin -f "https://github.com/cloudfoundry/log-cache-cli/releases/download/v${CF_LOG_CACHE_VERSION}/log-cache-cf-plugin-linux"
 
 # Install the AWS-CLI
-RUN pip install awscli=="1.14.10"
+RUN pip install awscli=="1.19.112"

--- a/cf-cli/Dockerfile
+++ b/cf-cli/Dockerfile
@@ -2,7 +2,7 @@ FROM ghcr.io/alphagov/paas/ruby-base:main
 
 ENV PACKAGES "unzip curl openssl ca-certificates git libc6-compat bash jq gettext make"
 ENV CF_CLI_VERSION "8.6.0"
-ENV SPRUCE_VERSION "1.27.0"
+ENV SPRUCE_VERSION "1.30.2"
 
 RUN apk add --no-cache $PACKAGES
 

--- a/cf-uaac/Dockerfile
+++ b/cf-uaac/Dockerfile
@@ -2,4 +2,4 @@ FROM ghcr.io/alphagov/paas/ruby-base:main
 
 RUN apk add --no-cache musl-dev gcc make g++
 
-RUN gem install cf-uaac -v 4.7.0 --no-document
+RUN gem install cf-uaac -v 4.14.0 --no-document

--- a/curl-ssl/Dockerfile
+++ b/curl-ssl/Dockerfile
@@ -3,4 +3,4 @@ FROM ghcr.io/alphagov/paas/alpine:main
 RUN apk add --no-cache \
     jq~1 \
     gettext~0.21 \
-    curl~7
+    curl~8

--- a/fast-startup-and-shutdown/Dockerfile
+++ b/fast-startup-and-shutdown/Dockerfile
@@ -1,6 +1,6 @@
 FROM ghcr.io/alphagov/paas/bosh-cli-v2:main
 
-ENV AWSCLI_VERSION "1.27.90"
+ENV AWSCLI_VERSION "1.19.112"
 
 RUN apt-get update && apt-get install -y \
   curl \

--- a/git-ssh/Dockerfile
+++ b/git-ssh/Dockerfile
@@ -2,7 +2,7 @@ FROM ghcr.io/alphagov/paas/alpine:main
 
 RUN apk add --no-cache \
         git~2 \
-        curl~7 \
+        curl~8 \
         openssh-client-default~9 \
         gnupg~2.2 \
         bash~5.1

--- a/golang/Dockerfile
+++ b/golang/Dockerfile
@@ -1,1 +1,1 @@
-FROM golang:1.16
+FROM golang:1.18

--- a/paas-prometheus-exporter/Dockerfile
+++ b/paas-prometheus-exporter/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.14 AS build
+FROM golang:1.18 AS build
 
 ENV COMMIT_SHA c02e5624a2098d7b4593ab2da56ad6f4cfbf8d24
 ENV REPO_URL https://github.com/alphagov/paas-prometheus-exporter.git

--- a/self-update-pipelines/Dockerfile
+++ b/self-update-pipelines/Dockerfile
@@ -1,6 +1,6 @@
 FROM ruby:3.1-slim-buster
 
-ENV AWSCLI_VERSION "1.17.2"
+ENV AWSCLI_VERSION "1.19.112"
 ENV PACKAGES make python-setuptools python-pip groff less curl
 
 RUN apt-get update \

--- a/self-update-pipelines/self-update-pipelines_spec.rb
+++ b/self-update-pipelines/self-update-pipelines_spec.rb
@@ -3,7 +3,7 @@ require 'docker'
 require 'serverspec'
 
 AWSCLI_BIN = "/usr/local/bin/aws"
-AWSCLI_VERSION = "1.17.2"
+AWSCLI_VERSION = "1.19.112"
 
 describe "self-update-pipelines image" do
   before(:all) {

--- a/spruce/Dockerfile
+++ b/spruce/Dockerfile
@@ -1,6 +1,6 @@
 FROM ghcr.io/alphagov/paas/alpine:main
 
-ENV SPRUCE_VERSION 1.27.0
+ENV SPRUCE_VERSION 1.30.2
 
 RUN apk add --no-cache \
         wget~1 \


### PR DESCRIPTION
Descriptions:
- See commit for dependencies that are upgraded
- See [here](https://deployer.dev03.dev.cloudpipeline.digital/teams/main/pipelines/create-cloudfoundry/jobs/pipeline-lock/builds/24) for a clean run in our dev environment
