### PR TITLE
185509385 - Pin GitHub Actions to specific hashes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    commit-message:
+        prefix: "github-action"
   - package-ecosystem: "docker"
     directory: "/"
     schedule:

--- a/.github/workflows/build-image-base.yml
+++ b/.github/workflows/build-image-base.yml
@@ -45,11 +45,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.9.1
+        uses: styfle/cancel-workflow-action@bb6001c4ea612bf59c3abfc4756fbceee4f870c7
         with:
           access_token: ${{ secrets.GITHUB_TOKEN }}
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
         with:
           submodules: true
       - name: Log in to ghcr.io Container registry
@@ -61,7 +61,7 @@ jobs:
 
       - name: Extract metadata (tags, labels) for ghcr
         id: meta-ghcr
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@818d4b7b91585d195f67373fd9cb0332e31a7175
         with:
           images: ghcr.io/alphagov/paas/${{ inputs.image }}
           tags: |
@@ -76,7 +76,7 @@ jobs:
             org.opencontainers.image.title=GOV.UK PaaS ${{ inputs.image }}
       - name: Extract metadata (tags, labels) for docker hub
         id: meta-dockerhub
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@818d4b7b91585d195f67373fd9cb0332e31a7175
         with:
           images: governmentpaas/${{ inputs.image }}
           tags: |
@@ -91,22 +91,22 @@ jobs:
             org.opencontainers.image.title=GOV.UK PaaS ${{ inputs.image }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@2b82ce82d56a2a04d2637cd93a637ae1b359c0a7
         with:
           platforms: ${{ inputs.platforms }}
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@2a1a44ac4aa01993040736bd95bb470da1a38365
 
       - name: Check if there are acceptance tests
         id: check_for_tests
-        uses: andstor/file-existence-action@v1
+        uses: andstor/file-existence-action@20b4d2e596410855db8f9ca21e96fbe18e12930b
         with:
           files: "./${{ inputs.image }}/${{ inputs.image }}_spec.rb"
 
       - name: Build for acceptance test
         if: steps.check_for_tests.outputs.files_exist == 'true'
-        uses: docker/build-push-action@v3.2.0
+        uses: docker/build-push-action@2eb1c1961a95fc15694676618e422e8ba1d63825
         with:
           context: ./${{ inputs.image }}
           file: ./${{ inputs.image }}/${{inputs.dockerfile}}
@@ -118,7 +118,7 @@ jobs:
           platforms: ${{ inputs.platforms }}
 
       - name: Set up ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@d3c9825d67b0d8720afdfdde5af56c79fdb38d16
         with:
           bundler-cache: true
         if: steps.check_for_tests.outputs.files_exist == 'true'
@@ -129,7 +129,7 @@ jobs:
         if: steps.check_for_tests.outputs.files_exist == 'true'
 
       - name: Build and push to ghcr
-        uses: docker/build-push-action@v3.2.0
+        uses: docker/build-push-action@2eb1c1961a95fc15694676618e422e8ba1d63825
         with:
           context: ./${{ inputs.image }}
           platforms: ${{ inputs.platforms }}
@@ -147,7 +147,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Build and push to docker hub
-        uses: docker/build-push-action@v3.2.0
+        uses: docker/build-push-action@2eb1c1961a95fc15694676618e422e8ba1d63825
         with:
           context: ./${{ inputs.image }}
           platforms: ${{ inputs.platforms }}

--- a/.github/workflows/lint_on_pr.yml
+++ b/.github/workflows/lint_on_pr.yml
@@ -16,16 +16,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.9.1
+        uses: styfle/cancel-workflow-action@bb6001c4ea612bf59c3abfc4756fbceee4f870c7
         with:
           access_token: ${{ secrets.GITHUB_TOKEN }}
       - name: Checkout Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
         with:
           fetch-depth: 0
 
       - name: Lint Code Base (Blocking) # Blow up on gitleaks / github actions errors (ie. things which may / will cause issues)
-        uses: github/super-linter@v4
+        uses: github/super-linter@98b9f97a88465a982d87e5a4264a87a3d3958560
         env:
           VALIDATE_ALL_CODEBASE: false
           DEFAULT_BRANCH: main
@@ -35,7 +35,7 @@ jobs:
           VALIDATE_GITHUB_ACTIONS: true
 
       - name: Lint Code Base (Information only) # Run linter on everything else, but in 'information-only' mode.
-        uses: github/super-linter@v4
+        uses: github/super-linter@98b9f97a88465a982d87e5a4264a87a3d3958560
         env:
           VALIDATE_ALL_CODEBASE: false
           DEFAULT_BRANCH: main


### PR DESCRIPTION
Description:
- Currently we pin to versions which means that we automatically pull in the latest changes which presents a security risk as we don't know which code is running in our build pipeline.
- This PR fixes this by pinning to a specific hash

## How to review

Verify that GitHub actions successfully run
