### PR TITLE
Updates to bosh-cli-v2

### DIFF
--- a/bosh-cli-v2/Dockerfile
+++ b/bosh-cli-v2/Dockerfile
@@ -1,7 +1,7 @@
 FROM ruby:3.1-slim-buster
 
-ENV BOSH_CLI_VERSION 6.4.17
-ENV BOSH_CLI_SUM d0917d3ad0ff544a4c69a7986e710fe48e8cb2207717f77db31905d639e28c18
+ENV BOSH_CLI_VERSION 7.3.1
+ENV BOSH_CLI_SUM f6f80461208f186aa3587b25abc12b86e217e7c96594e335de3c17f4ed683a3f
 ENV BOSH_CLI_FILENAME bosh-cli-${BOSH_CLI_VERSION}-linux-amd64
 
 ENV DEBIAN_PACKAGES "ca-certificates wget git openssh-client file jq"
@@ -10,8 +10,10 @@ ENV DEBIAN_PACKAGES "ca-certificates wget git openssh-client file jq"
 ENV BOSH_ENV_DEPS "build-essential zlibc zlib1g-dev openssl libxslt1-dev \
   libxml2-dev libssl-dev libreadline7 libreadline-dev libyaml-dev libsqlite3-dev sqlite3"
 
-ENV BOSH_AWS_CPI_URL https://bosh.io/d/github.com/cloudfoundry/bosh-aws-cpi-release?v=97
-ENV BOSH_AWS_CPI_CHECKSUM b6aa84bc178e5cc99faa55a89943214c33488d5f
+# These versions are used for caching so that we don't have to rebuild the cpi each time
+# we do the bosh-deploy. This will save around 3-4 mins each deploy
+ENV BOSH_AWS_CPI_URL https://bosh.io/d/github.com/cloudfoundry/bosh-aws-cpi-release?v=99
+ENV BOSH_AWS_CPI_CHECKSUM ffc4a06d6728d88eb108418f886f46428c2a1bf2
 
 RUN apt-get update \
   && apt-get -y upgrade \
@@ -28,8 +30,8 @@ COPY bosh_init_cache /tmp/bosh_init_cache/
 RUN /tmp/bosh_init_cache/seed_bosh_init_cache.sh && \
     rm -rf /tmp/bosh_init_cache
 
-ENV CREDHUB_CLI_VERSION 2.9.14
-ENV CREDHUB_CLI_SUM 79cf9100fd4e0c9024752b097911406bc73d387c985c72330598ba445eb92bfb
+ENV CREDHUB_CLI_VERSION 2.9.19
+ENV CREDHUB_CLI_SUM dcb942badda5db92ed25fa20eefe110a39f8af31ae6cd978aa5b1f0241ae05a6
 ENV CREDHUB_CLI_FILENAME credhub-linux-${CREDHUB_CLI_VERSION}.tgz
 
 RUN wget -nv https://github.com/cloudfoundry-incubator/credhub-cli/releases/download/${CREDHUB_CLI_VERSION}/${CREDHUB_CLI_FILENAME} \
@@ -38,8 +40,8 @@ RUN wget -nv https://github.com/cloudfoundry-incubator/credhub-cli/releases/down
   && chmod +x credhub \
   && mv credhub /usr/local/bin/credhub
 
-ENV YQ_VERSION 4.26.1
-ENV YQ_SUM 9e35b817e7cdc358c1fcd8498f3872db169c3303b61645cc1faf972990f37582
+ENV YQ_VERSION 4.35.1
+ENV YQ_SUM bd695a6513f1196aeda17b174a15e9c351843fb1cef5f9be0af170f2dd744f08
 ENV YQ_FILENAME yq_linux_amd64
 
 RUN wget -nv https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/${YQ_FILENAME} \

--- a/bosh-cli-v2/bosh-cli-v2_spec.rb
+++ b/bosh-cli-v2/bosh-cli-v2_spec.rb
@@ -99,7 +99,5 @@ describe "bosh-cli-v2 image" do
 
     cpi_package = compiled_packages.find {|p| p["Key"]["PackageName"] == "bosh_aws_cpi" }
     expect(cpi_package).to be
-
-    expect(file("#{installation_path}/packages/bosh_aws_cpi/bin/aws_cpi")).to be_executable
   end
 end

--- a/bosh-cli-v2/bosh-cli-v2_spec.rb
+++ b/bosh-cli-v2/bosh-cli-v2_spec.rb
@@ -2,8 +2,8 @@ require 'spec_helper'
 require 'docker'
 require 'serverspec'
 
-BOSH_CLI_VERSION="6.4.17-f0454a75-2022-02-25T00:42:57Z"
-CREDHUB_VERSION='2.9.14'
+BOSH_CLI_VERSION="7.3.1-c569e51d5-2023-07-13T21:19:29Z"
+CREDHUB_VERSION='2.9.19'
 
 BOSH_ENV_DEPS = "build-essential zlibc zlib1g-dev openssl libxslt1-dev libxml2-dev \
     libssl-dev libreadline7 libreadline-dev libyaml-dev libsqlite3-dev sqlite3"

--- a/bosh-cli-v2/bosh_init_cache/seed_bosh_init_cache.sh
+++ b/bosh-cli-v2/bosh_init_cache/seed_bosh_init_cache.sh
@@ -23,4 +23,9 @@ set +e
 bosh create-env minimal.yml
 set -e
 
+# We only care about the compiled_packages.json and blobs folder.
+# Keeping this about can cause issues if the cpi has packages that
+# are not idempotent.
+rm -r /root/.bosh/installations/44f01911-a47a-4a24-6ca3-a3109b33f058/packages
+
 echo "...done"


### PR DESCRIPTION
## What

Version updates to bosh-cli-v2 container:

- bump bosh cli version to 7.3.1
- bump bosh aws cpi to version 99
- bump credhub cli version to 2.9.19
- bump yq version to 4.35.1

Clean up packages folder at the end of the bosh create-env.

If we don't clean the packages and we have a different cpi version built upstream we can get "idempotent" issues.

For example:

```
mkdir: cannot create directory '/root/.bosh/installations/44f01911-a47a-4a24-6ca3-a3109b33f058/packages/aws-cpi-ruby-3.1/bosh': File exists
```

[Example build failure](https://deployer.dev04.dev.cloudpipeline.digital/teams/main/pipelines/create-bosh-concourse/jobs/bosh-deploy/builds/30#L64ab2e1b:2092)

## How to review

Look at the changes.
These changes have been test against dev-04. Both paas-bootstrap and paas-cf.
