### PR TITLE
186049138 - Update awscli image to include openssh

### DIFF
--- a/awscli/Dockerfile
+++ b/awscli/Dockerfile
@@ -7,6 +7,7 @@ RUN apk add --no-cache \
         less>=590-r0 \
         python3~3.10 \
         py3-pip~22 \
+        openssh \
     && pip3 install \
         awscli==$AWSCLI_VERSION \
         pyyaml==5.3.1


### PR DESCRIPTION
## Description:
- paas-bootstrap's create-bosh-concourse [pipeline](https://github.com/alphagov/paas-bootstrap/blob/9061827f4c35ac844d1e4dfdefb2eb3e167cf13f/concourse/pipelines/create-bosh-concourse.yml#L645) installs openssh using apk but it should be bundled as part of the docker image
- Bundle openssh into the awscli docker image

## How to review

- See [https://deployer.dev02.dev.cloudpipeline.digital/teams/main/pipelines/create-bosh-concourse/jobs/update-pipeline/builds/15](https://deployer.dev02.dev.cloudpipeline.digital/teams/main/pipelines/create-bosh-concourse/jobs/update-pipeline/builds/15) for a clean run of `create-bosh-concourse`
- See [https://deployer.dev02.dev.cloudpipeline.digital/teams/main/pipelines/create-cloudfoundry/jobs/pipeline-lock/builds/70](https://deployer.dev02.dev.cloudpipeline.digital/teams/main/pipelines/create-cloudfoundry/jobs/pipeline-lock/builds/70) for a clean run of `create-cloudfoundry`
- See [https://github.com/alphagov/paas-release-ci/pull/250](https://github.com/alphagov/paas-release-ci/pull/250) for links to successful runs in Concourse for CI
