### PR TITLE
186049138 - awscli docker image uses openssh-client rather than openssh

### DIFF
--- a/awscli/Dockerfile
+++ b/awscli/Dockerfile
@@ -7,7 +7,7 @@ RUN apk add --no-cache \
         less>=590-r0 \
         python3~3.10 \
         py3-pip~22 \
-        openssh \
+        openssh-client \
     && pip3 install \
         awscli==$AWSCLI_VERSION \
         pyyaml==5.3.1


### PR DESCRIPTION
## Description:
- There is no need for the server packages as in paas-bootstrap we only use it to generate ssh-keys

## How to review

- See successful run at https://deployer.dev02.dev.cloudpipeline.digital/teams/main/pipelines/create-bosh-concourse/jobs/test-aws-cli-image/builds/2
- See successful run at https://deployer.dev02.dev.cloudpipeline.digital/teams/main/pipelines/create-cloudfoundry/jobs/pipeline-lock/builds/72
- See successful run at https://concourse.build.ci.cloudpipeline.digital/teams/main/pipelines/setup/jobs/self-update/builds/108
