### PR TITLE
updating ubuntu bionic->jammy

### DIFF
--- a/ubuntu/Dockerfile
+++ b/ubuntu/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:bionic
+FROM ubuntu:jammy
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt update \


### PR DESCRIPTION
## What

we need to update these refs to the old bionic ubuntu versions as the apt repos seem to have been removed, which is preventing the pipelines running on the billing integration tests...

## How to review

Look at the code
