### PR TITLE
updating ubuntu bionic->jammy

### DIFF
--- a/certstrap/certstrap_spec.rb
+++ b/certstrap/certstrap_spec.rb
@@ -12,7 +12,7 @@ describe "certstrap image" do
   }
 
   it "installs the right version of Ubuntu Linux" do
-    expect(os_version).to include("Ubuntu 18.04.6")
+    expect(os_version).to include("Ubuntu 22.04.3")
     expect(os_version).to include("LTS")
   end
 

--- a/cf-acceptance-tests/Dockerfile
+++ b/cf-acceptance-tests/Dockerfile
@@ -5,7 +5,7 @@ RUN apt update \
       build-essential \
       openssh-client \
       unzip \
-      python-pip \
+      python3-pip \
       jq \
       git \
       fossil \
@@ -40,4 +40,4 @@ ENV CF_PLUGIN_HOME /root/
 RUN cf install-plugin -f "https://github.com/cloudfoundry/log-cache-cli/releases/download/v${CF_LOG_CACHE_VERSION}/log-cache-cf-plugin-linux"
 
 # Install the AWS-CLI
-RUN pip install awscli=="1.19.112"
+RUN pip install awscli=="1.29.79"


### PR DESCRIPTION
## What

we need to update these refs to the old bionic ubuntu versions as the apt repos seem to have been removed, which is preventing the pipelines running on the billing integration tests...

## How to review

Look at the code
