### PR TITLE
[186049138] Postgresql is used in acceptance tests

### DIFF
--- a/cf-acceptance-tests/Dockerfile
+++ b/cf-acceptance-tests/Dockerfile
@@ -1,17 +1,20 @@
 FROM ghcr.io/alphagov/paas/ubuntu:main
 
-RUN apt update \
-    && apt install -y \
-      build-essential \
-      openssh-client \
-      unzip \
-      python3-pip \
-      jq \
-      git \
-      fossil \
-      mercurial \
-      bzr \
-      subversion
+RUN wget -qO- https://www.postgresql.org/media/keys/ACCC4CF8.asc > /etc/apt/trusted.gpg.d/ACCC4CF8.asc \
+  && echo "deb http://apt.postgresql.org/pub/repos/apt/ jammy-pgdg main" > /etc/apt/sources.list.d/pgdg.list
+RUN apt update && apt install -y \
+  build-essential \
+  openssh-client \
+  unzip \
+  python3-pip \
+  jq \
+  git \
+  fossil \
+  mercurial \
+  bzr \
+  subversion \
+  postgresql-12 \
+  postgresql-client-12
 
 ENV GOPATH /go
 ENV PATH /go/bin:/usr/local/go/bin:$PATH
@@ -30,8 +33,8 @@ RUN go install github.com/onsi/ginkgo/v2/ginkgo@latest
 
 # Install the cf CLI
 RUN wget -q -O cf.deb "https://packages.cloudfoundry.org/stable?release=debian64&version=${CF_CLI_VERSION}&source=github-rel" && \
-    dpkg -i cf.deb && \
-    rm -f cf.deb
+  dpkg -i cf.deb && \
+  rm -f cf.deb
 
 # Setup plugins
 ENV CF_PLUGIN_HOME /root/

--- a/cf-acceptance-tests/cf-acceptance-tests_spec.rb
+++ b/cf-acceptance-tests/cf-acceptance-tests_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 require 'docker'
 require 'serverspec'
+require 'pathname'
 
 GO_VERSION="1.21.1"
 CF_CLI_VERSION="8.6.0"
@@ -56,6 +57,16 @@ describe "cf-acceptance-tests image" do
     expect(
       command("jq --version").exit_status
     ).to eq(0)
+  end
+
+  it "has psql available" do
+    expect(
+      command("psql --version").exit_status
+    ).to eq(0)
+  end
+
+  it "has postgresql startup script" do
+    expect(Pathname.new('/usr/bin/pg_ctlcluster')).to exist
   end
 
   it "has the CF_PLUGIN_HOME variable set" do


### PR DESCRIPTION
## What

We are trying to eliminate any apt-get install remnants in our pipelines by loading requirements in the docker images.
This PR will include postgresql and postgresql-client needed in acceptance-tests.

## How to review

Verify that the image contains postgresql and postgresql-client installed.
