### PR TITLE
bumped aws cpi 99->101

### DIFF
--- a/bosh-cli-v2/Dockerfile
+++ b/bosh-cli-v2/Dockerfile
@@ -12,8 +12,8 @@ ENV BOSH_ENV_DEPS "build-essential zlibc zlib1g-dev openssl libxslt1-dev \
 
 # These versions are used for caching so that we don't have to rebuild the cpi each time
 # we do the bosh-deploy. This will save around 3-4 mins each deploy
-ENV BOSH_AWS_CPI_URL https://bosh.io/d/github.com/cloudfoundry/bosh-aws-cpi-release?v=99
-ENV BOSH_AWS_CPI_CHECKSUM ffc4a06d6728d88eb108418f886f46428c2a1bf2
+ENV BOSH_AWS_CPI_URL https://bosh.io/d/github.com/cloudfoundry/bosh-aws-cpi-release?v=101
+ENV BOSH_AWS_CPI_CHECKSUM 12d320570e00636f1e455e588e0462465b02d86a
 
 RUN apt-get update \
   && apt-get -y upgrade \


### PR DESCRIPTION
## What

bumped aws cpi 99->101 to support new instance generation disk layouts

## How to review

look at the code, and/or the deploy in dev04
