### PR TITLE
Fix GitHub actions CI

### DIFF
--- a/.github/workflows/build-image-base.yml
+++ b/.github/workflows/build-image-base.yml
@@ -122,7 +122,7 @@ jobs:
           platforms: ${{ inputs.test_platform }}
 
       - name: Set up ruby
-        uses: ruby/setup-ruby@5cfe23c062c0aac352e765b1b7cc12ea5255ccc4
+        uses: ruby/setup-ruby@32110d4e311bd8996b2a82bf2a43b714ccc91777
         with:
           bundler-cache: true
         if: steps.check_for_tests.outputs.files_exists == 'true'

--- a/bosh-cli-v2/Dockerfile
+++ b/bosh-cli-v2/Dockerfile
@@ -3,6 +3,7 @@ FROM ruby:3.1-slim-buster
 ENV BOSH_CLI_VERSION 7.3.1
 ENV BOSH_CLI_SUM f6f80461208f186aa3587b25abc12b86e217e7c96594e335de3c17f4ed683a3f
 ENV BOSH_CLI_FILENAME bosh-cli-${BOSH_CLI_VERSION}-linux-amd64
+ENV BOSH_CLI_PATH v${BOSH_CLI_VERSION}/${BOSH_CLI_FILENAME}
 
 ENV DEBIAN_PACKAGES "ca-certificates wget git openssh-client file jq"
 
@@ -21,14 +22,14 @@ RUN apt-get update \
   && apt-get install -y --no-install-recommends ${BOSH_ENV_DEPS} \
   && rm -rf /var/lib/apt/lists/*
 
-RUN wget -nv https://s3.amazonaws.com/bosh-cli-artifacts/${BOSH_CLI_FILENAME} \
+RUN wget -nv https://github.com/cloudfoundry/bosh-cli/releases/download/${BOSH_CLI_PATH} \
   && echo "${BOSH_CLI_SUM}  ${BOSH_CLI_FILENAME}" | sha256sum -c - \
   && chmod +x ${BOSH_CLI_FILENAME} \
   && mv ${BOSH_CLI_FILENAME} /usr/local/bin/bosh
 
 COPY bosh_init_cache /tmp/bosh_init_cache/
 RUN /tmp/bosh_init_cache/seed_bosh_init_cache.sh && \
-    rm -rf /tmp/bosh_init_cache
+  rm -rf /tmp/bosh_init_cache
 
 ENV CREDHUB_CLI_VERSION 2.9.19
 ENV CREDHUB_CLI_SUM dcb942badda5db92ed25fa20eefe110a39f8af31ae6cd978aa5b1f0241ae05a6

--- a/cf-uaac/Dockerfile
+++ b/cf-uaac/Dockerfile
@@ -2,4 +2,4 @@ FROM ghcr.io/alphagov/paas/ruby-base:main
 
 RUN apk add --no-cache musl-dev gcc make g++
 
-RUN gem install cf-uaac -v 4.14.0 --no-document
+RUN gem install cf-uaac -v 4.27.0 --no-document

--- a/cf-uaac/cf-uaac_spec.rb
+++ b/cf-uaac/cf-uaac_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'docker'
 require 'serverspec'
 
-UAAC_VERSION="4.14.0"
+UAAC_VERSION="4.27.0"
 
 describe "cf-uaac image" do
   before(:all) {

--- a/middleman/Dockerfile
+++ b/middleman/Dockerfile
@@ -1,12 +1,12 @@
-FROM ghcr.io/alphagov/paas/ruby:main
+FROM ruby:3.4-slim
 
 RUN apt update \
     && apt install -y \
-        build-essential \
-        libffi-dev \
-        git \
-        libcurl4-openssl-dev \
-        nodejs
+    build-essential \
+    libffi-dev \
+    git \
+    libcurl4-openssl-dev \
+    nodejs
 
-RUN gem install \
-        middleman
+RUN gem install concurrent-ruby -v 1.3.4
+RUN gem install middleman

--- a/ruby/Dockerfile
+++ b/ruby/Dockerfile
@@ -1,1 +1,1 @@
-FROM ruby:3.1-slim
+FROM ruby:3.4-slim


### PR DESCRIPTION
Fixes:
* Fixed the bosh CLI download URL, these are now hosted on github releases and the old S3 bucket doesn't have the releases anymore
* Update the UAAC version, the old version fails to launch
* Bump the setup ruby github action version
* Install concurrent-ruby before middleman as a workaround for https://github.com/middleman/middleman/issues/2788
* Update ruby version to 3.4. Use the docker hub image directly in middleman for now

We should change the middleman base image back to paas-ruby after merging this, it currently uses the latest tagged version (3.1) but middleman needs ruby >= 3.2 to work. Underlying issue is https://github.com/middleman/middleman/issues/2788